### PR TITLE
Add dictionary literal support for action parameters

### DIFF
--- a/Examples/dictionary-test.perspective
+++ b/Examples/dictionary-test.perspective
@@ -1,0 +1,24 @@
+#name: Dictionary API Test
+#icon: globe
+#color: blue
+
+// POST with headers and nested JSON body
+downloadURL(
+  url: "https://jsonplaceholder.typicode.com/posts",
+  method: "POST",
+  headers: {
+    "Authorization": "Bearer my-secret-token",
+    "Accept": "application/json"
+  },
+  bodyType: "JSON",
+  body: {
+    "title": "Hello from Perspective",
+    "userId": 1,
+    "completed": false,
+    "metadata": {
+      "source": "perspective-cuts",
+      "version": 2
+    }
+  }
+) -> result
+showResult(text: result)

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -58,14 +58,19 @@ struct Compiler: Sendable {
                     parameters: ["WFCommentActionText": text]
                 ))
             case .variableDeclaration(let name, let value, _, _):
-                // Emit a setVariable action
-                let textAction = try buildTextAction(from: value)
-                actions.append(textAction)
+                // Emit the appropriate action based on expression type
+                let sourceAction: [String: Any]
+                if case .dictionaryLiteral = value {
+                    sourceAction = try buildDictionaryAction(from: value)
+                } else {
+                    sourceAction = try buildTextAction(from: value)
+                }
+                actions.append(sourceAction)
                 actions.append(buildAction(
                     identifier: "is.workflow.actions.setvariable",
                     parameters: [
                         "WFVariableName": name,
-                        "WFInput": buildMagicVariable(outputOf: textAction)
+                        "WFInput": buildMagicVariable(outputOf: sourceAction)
                     ]
                 ))
             case .actionCall(let name, let arguments, let output, let location):
@@ -311,6 +316,15 @@ struct Compiler: Sendable {
         ]
     }
 
+    private func buildDictionaryAction(from expression: Expression) throws -> [String: Any] {
+        let value = try expressionToValue(expression)
+        let uuid = UUID().uuidString
+        return buildAction(
+            identifier: "is.workflow.actions.dictionary",
+            parameters: ["WFItems": value, "UUID": uuid]
+        )
+    }
+
     private func buildTextAction(from expression: Expression) throws -> [String: Any] {
         let value = try expressionToValue(expression)
         let uuid = UUID().uuidString
@@ -338,6 +352,7 @@ struct Compiler: Sendable {
         case .stringLiteral(let s): return s
         case .numberLiteral(let n): return n == n.rounded() ? Int(n) : n
         case .boolLiteral(let b): return b
+        case .dictionaryLiteral: return try expressionToValue(expr)
         default: return try expressionToValue(expr)
         }
     }
@@ -406,6 +421,39 @@ struct Compiler: Sendable {
             return [
                 "Value": ["string": text, "attachmentsByRange": attachments],
                 "WFSerializationType": "WFTextTokenString"
+            ] as [String: Any]
+        case .dictionaryLiteral(let entries):
+            var items: [[String: Any]] = []
+            for (keyExpr, valueExpr) in entries {
+                var item: [String: Any] = [:]
+                item["WFKey"] = try expressionToValueWithOutputMap(keyExpr, outputMap: outputMap)
+
+                switch valueExpr {
+                case .numberLiteral(let n):
+                    item["WFItemType"] = 3
+                    let s = n == n.rounded() ? String(Int(n)) : String(n)
+                    item["WFValue"] = [
+                        "Value": ["string": s, "attachmentsByRange": [String: Any]()],
+                        "WFSerializationType": "WFTextTokenString"
+                    ] as [String: Any]
+                case .boolLiteral(let b):
+                    item["WFItemType"] = 4
+                    item["WFValue"] = [
+                        "Value": b,
+                        "WFSerializationType": "WFNumberSubstitutableState"
+                    ] as [String: Any]
+                case .dictionaryLiteral:
+                    item["WFItemType"] = 1
+                    item["WFValue"] = try expressionToValueWithOutputMap(valueExpr, outputMap: outputMap)
+                default:
+                    item["WFItemType"] = 0
+                    item["WFValue"] = try expressionToValueWithOutputMap(valueExpr, outputMap: outputMap)
+                }
+                items.append(item)
+            }
+            return [
+                "Value": ["WFDictionaryFieldValueItems": items],
+                "WFSerializationType": "WFDictionaryFieldValue"
             ] as [String: Any]
         }
     }

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -61,7 +61,7 @@ struct Compiler: Sendable {
                 // Emit the appropriate action based on expression type
                 let sourceAction: [String: Any]
                 if case .dictionaryLiteral = value {
-                    sourceAction = try buildDictionaryAction(from: value)
+                    sourceAction = try buildDictionaryAction(from: value, outputMap: outputMap)
                 } else {
                     sourceAction = try buildTextAction(from: value)
                 }
@@ -316,12 +316,12 @@ struct Compiler: Sendable {
         ]
     }
 
-    private func buildDictionaryAction(from expression: Expression) throws -> [String: Any] {
-        let value = try expressionToValue(expression)
+    private func buildDictionaryAction(from expression: Expression, outputMap: [String: OutputRef]) throws -> [String: Any] {
+        let value = try expressionToValueWithOutputMap(expression, outputMap: outputMap)
         let uuid = UUID().uuidString
         return buildAction(
             identifier: "is.workflow.actions.dictionary",
-            parameters: ["WFItems": value, "UUID": uuid]
+            parameters: ["WFItems": value, "UUID": uuid, "CustomOutputName": "Dictionary"]
         )
     }
 
@@ -424,11 +424,11 @@ struct Compiler: Sendable {
             ] as [String: Any]
         case .dictionaryLiteral(let entries):
             var items: [[String: Any]] = []
-            for (keyExpr, valueExpr) in entries {
+            for entry in entries {
                 var item: [String: Any] = [:]
-                item["WFKey"] = try expressionToValueWithOutputMap(keyExpr, outputMap: outputMap)
+                item["WFKey"] = try expressionToValueWithOutputMap(entry.key, outputMap: outputMap)
 
-                switch valueExpr {
+                switch entry.value {
                 case .numberLiteral(let n):
                     item["WFItemType"] = 3
                     let s = n == n.rounded() ? String(Int(n)) : String(n)
@@ -444,10 +444,10 @@ struct Compiler: Sendable {
                     ] as [String: Any]
                 case .dictionaryLiteral:
                     item["WFItemType"] = 1
-                    item["WFValue"] = try expressionToValueWithOutputMap(valueExpr, outputMap: outputMap)
+                    item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap)
                 default:
                     item["WFItemType"] = 0
-                    item["WFValue"] = try expressionToValueWithOutputMap(valueExpr, outputMap: outputMap)
+                    item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap)
                 }
                 items.append(item)
             }

--- a/Sources/perspective-cuts/Parser/AST.swift
+++ b/Sources/perspective-cuts/Parser/AST.swift
@@ -26,6 +26,7 @@ enum Expression: Sendable {
     case boolLiteral(Bool)
     case variableReference(String)
     case interpolatedString(parts: [StringPart])
+    case dictionaryLiteral([(key: Expression, value: Expression)])
 }
 
 enum StringPart: Sendable {

--- a/Sources/perspective-cuts/Parser/AST.swift
+++ b/Sources/perspective-cuts/Parser/AST.swift
@@ -20,13 +20,18 @@ enum ASTNode: Sendable {
     case returnStatement(value: Expression?, location: SourceLocation)
 }
 
+struct DictionaryEntry: Sendable {
+    let key: Expression
+    let value: Expression
+}
+
 enum Expression: Sendable {
     case stringLiteral(String)
     case numberLiteral(Double)
     case boolLiteral(Bool)
     case variableReference(String)
     case interpolatedString(parts: [StringPart])
-    case dictionaryLiteral([(key: Expression, value: Expression)])
+    case dictionaryLiteral([DictionaryEntry])
 }
 
 enum StringPart: Sendable {

--- a/Sources/perspective-cuts/Parser/Parser.swift
+++ b/Sources/perspective-cuts/Parser/Parser.swift
@@ -384,9 +384,56 @@ struct Parser: Sendable {
         case .identifier(let name):
             pos += 1
             return .variableReference(name)
+        case .leftBrace:
+            return try parseDictionaryLiteral(&pos)
         default:
             throw ParserError(message: "Expected expression, got \(token.kind)", location: token.location)
         }
+    }
+
+    private func parseDictionaryLiteral(_ pos: inout Int) throws -> Expression {
+        let loc = tokens[pos].location
+        pos += 1 // skip {
+        var entries: [(key: Expression, value: Expression)] = []
+
+        skipNewlines(&pos)
+        while pos < tokens.count && tokens[pos].kind != .rightBrace {
+            skipNewlines(&pos)
+            if tokens[pos].kind == .rightBrace { break }
+
+            // Parse key (string literal or identifier)
+            let key: Expression
+            switch tokens[pos].kind {
+            case .stringLiteral(let s):
+                key = .stringLiteral(s)
+                pos += 1
+            case .identifier(let name):
+                key = .stringLiteral(name)
+                pos += 1
+            default:
+                throw ParserError(message: "Expected dictionary key (string or identifier)", location: tokens[pos].location)
+            }
+
+            guard pos < tokens.count, tokens[pos].kind == .colon else {
+                throw ParserError(message: "Expected ':' after dictionary key", location: tokens[pos].location)
+            }
+            pos += 1 // skip :
+            skipNewlines(&pos)
+
+            let value = try parseExpression(&pos)
+            entries.append((key: key, value: value))
+
+            skipNewlines(&pos)
+            if pos < tokens.count && tokens[pos].kind == .comma {
+                pos += 1
+                skipNewlines(&pos)
+            }
+        }
+        guard pos < tokens.count, tokens[pos].kind == .rightBrace else {
+            throw ParserError(message: "Expected '}' to close dictionary literal", location: loc)
+        }
+        pos += 1 // skip }
+        return .dictionaryLiteral(entries)
     }
 
     private func parseCondition(_ pos: inout Int) throws -> Condition {

--- a/Sources/perspective-cuts/Parser/Parser.swift
+++ b/Sources/perspective-cuts/Parser/Parser.swift
@@ -385,6 +385,9 @@ struct Parser: Sendable {
             pos += 1
             return .variableReference(name)
         case .leftBrace:
+            // Safe: block-level `{` is always consumed by statement parsers (if, repeat,
+            // for-each, menu, func) before reaching parseExpression, so `{` here is
+            // unambiguously a dictionary literal.
             return try parseDictionaryLiteral(&pos)
         default:
             throw ParserError(message: "Expected expression, got \(token.kind)", location: token.location)
@@ -394,7 +397,7 @@ struct Parser: Sendable {
     private func parseDictionaryLiteral(_ pos: inout Int) throws -> Expression {
         let loc = tokens[pos].location
         pos += 1 // skip {
-        var entries: [(key: Expression, value: Expression)] = []
+        var entries: [DictionaryEntry] = []
 
         skipNewlines(&pos)
         while pos < tokens.count && tokens[pos].kind != .rightBrace {
@@ -421,7 +424,7 @@ struct Parser: Sendable {
             skipNewlines(&pos)
 
             let value = try parseExpression(&pos)
-            entries.append((key: key, value: value))
+            entries.append(DictionaryEntry(key: key, value: value))
 
             skipNewlines(&pos)
             if pos < tokens.count && tokens[pos].kind == .comma {

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -183,7 +183,7 @@
           "key": "WFURL"
         },
         "method": {
-          "type": "string",
+          "type": "enum",
           "required": false,
           "key": "WFHTTPMethod"
         },
@@ -193,12 +193,12 @@
           "key": "WFHTTPHeaders"
         },
         "bodyType": {
-          "type": "string",
+          "type": "enum",
           "required": false,
           "key": "WFHTTPBodyType"
         },
         "body": {
-          "type": "variable",
+          "type": "dictionary",
           "required": false,
           "key": "WFRequestVariable"
         }


### PR DESCRIPTION
## Summary

- Adds `{ "key": value }` dictionary literal syntax to the Perspective language, enabling inline dictionaries for action parameters like HTTP headers and JSON request bodies
- Supports string, number, boolean, variable reference, and nested dictionary values with proper `WFDictionaryFieldValue` plist serialization
- Fixes `downloadURL` `method`/`bodyType` parameter types from `string` to `enum` so Shortcuts correctly applies the HTTP method and body type

Closes #2

## Example

```
downloadURL(
  url: "https://api.example.com/data",
  method: "POST",
  headers: {
    "Authorization": "Bearer token",
    "Accept": "application/json"
  },
  bodyType: "JSON",
  body: {
    "ref": "main",
    "inputs": {
      "live_booking": "true"
    }
  }
) -> response
```

## Test plan

- [ ] Compile `Examples/dictionary-test.perspective` with `--sign` and import into Shortcuts
- [ ] Verify HTTP headers appear in the Get Contents of URL action's Headers section
- [ ] Verify JSON body fields (including nested dictionaries) appear in the Request Body section
- [ ] Verify POST method is selected (not GET)
- [ ] Run the shortcut and confirm it makes a successful POST request
- [ ] Compile all existing examples to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)