### PR TITLE
Fix if/else conditional variable references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,6 @@ This project is in active development. Things change fast. If you want to contri
 ## What I Need Help With
 
 - **Action verification.** There are 180+ actions in the registry. Only 35 have been tested end-to-end. If you can test actions and report results, that is valuable.
-- **Fixing the if/else bug.** The condition compiler uses Variable type instead of ActionOutput with UUID for action outputs. This is the biggest known bug.
 - **The changeCase keyword conflict.** The word `case` is a parser keyword. The `changeCase` action cannot be used. This needs a parser fix.
 - **Enum parameter discovery.** Some actions use enum dropdowns that need special serialization (integers instead of strings, like `useModel`). Finding and documenting these is useful.
 - **New actions.** If Apple ships new actions or you find third party actions that need registry entries, submit them.

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -94,8 +94,6 @@ menu "Pick one" {
 }
 ```
 
-Note: if/else has a known issue where action output variables don't reference correctly. Use `useModel` to make decisions for now.
-
 ## Apple Intelligence
 
 This is where it gets interesting. The `useModel` action sends a prompt to Apple Intelligence. You can use the on-device model or Private Cloud Compute.
@@ -620,7 +618,6 @@ Plus third party app actions via raw identifiers (Perspective Intelligence, Chat
 
 ## Known Limitations
 
-- `if/else` does not correctly reference action output variables. Use `useModel` for decisions.
 - `changeCase` cannot be used because `case` is a parser keyword. Will be fixed.
 - `getCurrentWeather` is iOS only. Does not work on macOS.
 - Unlabeled arguments are silently dropped. Always use `label: value`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ See [PERSPECTIVE-LANGUAGE.md](PERSPECTIVE-LANGUAGE.md) for the complete language
 
 This is experimental. 35 actions have been tested end-to-end. 167 have verified identifiers. The compiler works. The language works. But there are known limitations:
 
-- `if/else` does not correctly reference action output variables
 - `changeCase` cannot be used because `case` is a parser keyword
 - `getCurrentWeather` is iOS only
 - Some enum parameters need special handling (like `useModel` needing integer values)

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -168,7 +168,7 @@ struct Compiler: Sendable {
                 let groupID = UUID().uuidString
                 // Emit conditional start
                 var condParams: [String: Any] = ["GroupingIdentifier": groupID, "WFControlFlowMode": 0]
-                try applyCondition(condition, to: &condParams)
+                try applyCondition(condition, to: &condParams, outputMap: outputMap)
                 actions.append(buildAction(identifier: "is.workflow.actions.conditional", parameters: condParams))
 
                 // Emit then body
@@ -458,28 +458,57 @@ struct Compiler: Sendable {
         }
     }
 
-    private func applyCondition(_ condition: Condition, to params: inout [String: Any]) throws {
+    private func applyCondition(_ condition: Condition, to params: inout [String: Any], outputMap: [String: OutputRef]) throws {
+        // Helper: resolve the left-hand side of a condition.
+        // Conditionals use a nested format for WFInput:
+        //   { Type: "Variable", Variable: { Value: { ... }, WFSerializationType: "WFTextTokenAttachment" } }
+        func resolveInput(_ expr: Expression) throws -> Any {
+            if case .variableReference(let name) = expr {
+                let inner: [String: Any]
+                if let ref = outputMap[name] {
+                    inner = [
+                        "Value": [
+                            "OutputUUID": ref.uuid,
+                            "Type": "ActionOutput",
+                            "OutputName": ref.name
+                        ],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ] as [String: Any]
+                } else {
+                    inner = [
+                        "Value": ["VariableName": name, "Type": "Variable"],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ] as [String: Any]
+                }
+                return [
+                    "Type": "Variable",
+                    "Variable": inner
+                ] as [String: Any]
+            }
+            return try expressionToValueWithOutputMap(expr, outputMap: outputMap)
+        }
+
         switch condition {
         case .equals(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 4 // equals
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .notEquals(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 5 // not equals
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .contains(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 99 // contains
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .greaterThan(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 2 // greater than
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .lessThan(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 3 // less than
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         }
     }
 


### PR DESCRIPTION
**Transparency note:** This work was done entirely using Claude Code. I completely understand if AI-generated contributions aren't something you want in the project — no hard feelings if you'd prefer to close this.

## Summary

This fixes the if/else variable reference bug listed in the README as a known limitation. Two issues in `applyCondition()`:

- It called `expressionToValue()` with an empty output map, so variable references in conditions could never resolve to their action output UUIDs. Now passes the real `outputMap` through.
- The `WFInput` format for conditionals requires a nested structure (`{Type: "Variable", Variable: {WFTextTokenAttachment}}`), not a bare `WFTextTokenAttachment`. Found by extracting a working shortcut from the Shortcuts SQLite database and comparing formats.

Also removes the "known issue" notes from the README, language reference, and contributing guide.

## Thank you

perspective-cuts has been a huge boon for our own work — thank you for building and sharing it. If this PR is welcome, we have additional fixes and features we'd be happy to contribute upstream.

## Test plan

- Compile a shortcut with an `if/else` that references an action output variable in the condition
- Verify the compiled shortcut runs correctly in the Shortcuts app

🤖 Generated with [Claude Code](https://claude.com/claude-code)