### PR TITLE
Add workflow surface metadata directives + several compiler fixes

### DIFF
--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -30,6 +30,9 @@ struct Compile: ParsableCommand {
     @Flag(name: .long, help: "Install directly to Shortcuts app (bypasses import, preserves all enum values)")
     var install: Bool = false
 
+    @Flag(name: .long, help: "After signing, open the shortcut so Shortcuts.app imports/updates it")
+    var open: Bool = false
+
     func run() throws {
         let source = try readSource(file)
         let tokens = try Lexer(source: source).tokenize()
@@ -66,6 +69,14 @@ struct Compile: ParsableCommand {
             try FileManager.default.removeItem(at: outputURL)
             try FileManager.default.moveItem(at: signedURL, to: outputURL)
             FileHandle.standardError.write(Data("Compiled and signed: \(outputURL.path)\n".utf8))
+            if open {
+                let task = Process()
+                task.launchPath = "/usr/bin/open"
+                task.arguments = [outputURL.path]
+                try? task.run()
+                task.waitUntilExit()
+                FileHandle.standardError.write(Data("Opened in Shortcuts.app for import.\n".utf8))
+            }
         } else {
             FileHandle.standardError.write(Data("Compiled: \(outputURL.path)\n".utf8))
             FileHandle.standardError.write(Data("Note: Run with --sign to create an importable shortcut.\n".utf8))

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -402,13 +402,13 @@ struct Compiler: Sendable {
         let v = value.trimmingCharacters(in: .whitespaces).lowercased()
         switch v {
         case "continue":
-            return ["Name": "ContinueWithInput", "Parameters": [String: Any]()]
+            return ["Name": "WFWorkflowNoInputBehaviorContinueWithInput", "Parameters": [String: Any]()]
         case "ask", "askforinput":
-            return ["Name": "AskForInput", "Parameters": [String: Any]()]
+            return ["Name": "WFWorkflowNoInputBehaviorAskForInput", "Parameters": [String: Any]()]
         case "clipboard", "getclipboard":
-            return ["Name": "GetClipboard", "Parameters": [String: Any]()]
+            return ["Name": "WFWorkflowNoInputBehaviorGetClipboard", "Parameters": [String: Any]()]
         case "cancel":
-            return ["Name": "ReturnToHomeScreen", "Parameters": [String: Any]()]
+            return ["Name": "WFWorkflowNoInputBehaviorReturnToHomeScreen", "Parameters": [String: Any]()]
         default:
             throw CompilerError(message: "Unknown #noinput value '\(value)'. Valid: continue, ask, clipboard, cancel", location: location)
         }
@@ -521,30 +521,39 @@ struct Compiler: Sendable {
         case .numberLiteral(let n): return n == n.rounded() ? Int(n) : n
         case .boolLiteral(let b): return b
         case .variableReference(let name):
-            // Use WFTextTokenString with attachmentsByRange -- this is how Apple's own shortcuts pass variables
+            // A bare variable reference (the entire field is the variable, not
+            // text containing it) is serialised as WFTextTokenAttachment with
+            // the descriptor at the top of `Value`. This is the form
+            // Shortcuts.app uses when it draws a vertical connection line
+            // between two action boxes; using WFTextTokenString here causes
+            // the boxes to render disconnected even though the data flows.
+            //
+            // The special name "ShortcutInput" maps to Apple's
+            // ExtensionInput token (the magic variable that represents
+            // whatever was passed in via Share Sheet / Quick Action / run
+            // input), not to a regular named variable.
+            if name == "ShortcutInput" {
+                return [
+                    "Value": ["Type": "ExtensionInput"],
+                    "WFSerializationType": "WFTextTokenAttachment"
+                ] as [String: Any]
+            }
             if let ref = outputMap[name] {
                 return [
                     "Value": [
-                        "string": "\u{FFFC}",
-                        "attachmentsByRange": [
-                            "{0, 1}": [
-                                "OutputName": ref.name,
-                                "OutputUUID": ref.uuid,
-                                "Type": "ActionOutput"
-                            ]
-                        ]
+                        "OutputName": ref.name,
+                        "OutputUUID": ref.uuid,
+                        "Type": "ActionOutput"
                     ],
-                    "WFSerializationType": "WFTextTokenString"
+                    "WFSerializationType": "WFTextTokenAttachment"
                 ] as [String: Any]
             }
             return [
                 "Value": [
-                    "string": "\u{FFFC}",
-                    "attachmentsByRange": [
-                        "{0, 1}": ["VariableName": name, "Type": "Variable"]
-                    ]
+                    "VariableName": name,
+                    "Type": "Variable"
                 ],
-                "WFSerializationType": "WFTextTokenString"
+                "WFSerializationType": "WFTextTokenAttachment"
             ] as [String: Any]
         case .interpolatedString(let parts):
             var text = ""

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -47,6 +47,8 @@ struct Compiler: Sendable {
         var menuBarEnabled = false
         // nil means "not set" -> use the full default content-class list.
         var explicitInputClasses: [String]? = nil
+        // nil means "not set" -> Shortcuts default ("Continue").
+        var noInputBehavior: [String: Any]? = nil
 
         for node in nodes {
             switch node {
@@ -80,6 +82,9 @@ struct Compiler: Sendable {
                 if key == "watch" {
                     watchEnabled = parseBoolDirective(value)
                 }
+                if key == "noinput" {
+                    noInputBehavior = try parseNoInputDirective(value: value, location: loc)
+                }
             case .comment(let text, _):
                 actions.append(buildAction(
                     identifier: "is.workflow.actions.comment",
@@ -103,12 +108,16 @@ struct Compiler: Sendable {
                 ))
             case .actionCall(let name, let arguments, let output, let location):
                 let def = registry.actions[name]
-                // If action contains dots, treat as raw identifier (3rd party app action)
-                let isThirdParty = def == nil && name.contains(".")
+                // If action contains dots, treat as raw identifier. Apple's own
+                // `is.workflow.actions.*` namespace is built-in territory even
+                // when the action is not in the registry — only treat names
+                // outside that namespace as 3rd-party App Intent actions.
+                let isAppleBuiltinRaw = def == nil && name.hasPrefix("is.workflow.actions.")
+                let isThirdParty = def == nil && name.contains(".") && !isAppleBuiltinRaw
                 let identifier: String
                 if let def {
                     identifier = def.identifier
-                } else if isThirdParty {
+                } else if isThirdParty || isAppleBuiltinRaw {
                     identifier = name
                 } else {
                     var msg = "Unknown action: '\(name)'"
@@ -169,6 +178,11 @@ struct Compiler: Sendable {
                                let intVal = valueMap[s] {
                                 resolvedValue = intVal
                             } else if let paramType = paramDef?.type, (paramType == "enum" || paramType == "boolean" || paramType == "plainString") {
+                                resolvedValue = try expressionToPlainValue(value)
+                            } else if isAppleBuiltinRaw && Compiler.appleBuiltinPlainKeys.contains(label) {
+                                // Raw Apple identifier with a known scalar key
+                                // (e.g. WFVariableName, Shell, InputMode, Script):
+                                // emit as plain value, not a tokenized text field.
                                 resolvedValue = try expressionToPlainValue(value)
                             } else {
                                 resolvedValue = try expressionToValueWithOutputMap(value, outputMap: outputMap)
@@ -302,7 +316,7 @@ struct Compiler: Sendable {
             }
         }
 
-        return [
+        var plist: [String: Any] = [
             "WFWorkflowMinimumClientVersionString": "900",
             "WFWorkflowMinimumClientVersion": 900,
             "WFWorkflowClientVersion": "1200",
@@ -322,7 +336,24 @@ struct Compiler: Sendable {
             "WFWorkflowActions": actions,
             "WFWorkflowName": shortcutName
         ]
+        if let noInputBehavior {
+            plist["WFWorkflowNoInputBehavior"] = noInputBehavior
+        }
+        return plist
     }
+
+    // For raw `is.workflow.actions.*` calls, these parameter labels are scalar
+    // settings (variable names, shell choice, script body, enum values) and
+    // must be emitted as plain strings — not wrapped in WFTextTokenString —
+    // so Shortcuts.app shows them correctly and writes them back unchanged.
+    private static let appleBuiltinPlainKeys: Set<String> = [
+        "WFVariableName",
+        "WFCommentActionText",
+        "Shell",
+        "InputMode",
+        "Script",
+        "WFTextActionText"
+    ]
 
     private static let defaultInputContentClasses: [String] = [
         "WFAppStoreAppContentItem",
@@ -359,6 +390,22 @@ struct Compiler: Sendable {
     private func parseBoolDirective(_ value: String) -> Bool {
         let v = value.trimmingCharacters(in: .whitespaces).lowercased()
         return v == "true" || v == "yes" || v == "1" || v == "on"
+    }
+
+    private func parseNoInputDirective(value: String, location: SourceLocation) throws -> [String: Any] {
+        let v = value.trimmingCharacters(in: .whitespaces).lowercased()
+        switch v {
+        case "continue":
+            return ["Name": "ContinueWithInput", "Parameters": [String: Any]()]
+        case "ask", "askforinput":
+            return ["Name": "AskForInput", "Parameters": [String: Any]()]
+        case "clipboard", "getclipboard":
+            return ["Name": "GetClipboard", "Parameters": [String: Any]()]
+        case "cancel":
+            return ["Name": "ReturnToHomeScreen", "Parameters": [String: Any]()]
+        default:
+            throw CompilerError(message: "Unknown #noinput value '\(value)'. Valid: continue, ask, clipboard, cancel", location: location)
+        }
     }
 
     private func parseInputDirective(value: String, location: SourceLocation) throws -> [String] {

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -172,6 +172,13 @@ struct Compiler: Sendable {
                                 })?.value
                             }
 
+                            // For built-in actions, map friendly name to plist key.
+                            // We need the plist key BEFORE choosing the serialisation
+                            // strategy because some Apple plist keys (e.g.
+                            // WFVariableName) must always be plain strings,
+                            // even when the parameter type is the generic "string".
+                            let plistKey = paramDef?.key ?? label
+
                             if let paramType = paramDef?.type, paramType == "enumInt",
                                let valueMap = paramDef?.valueMap,
                                case .stringLiteral(let s) = value,
@@ -179,17 +186,16 @@ struct Compiler: Sendable {
                                 resolvedValue = intVal
                             } else if let paramType = paramDef?.type, (paramType == "enum" || paramType == "boolean" || paramType == "plainString") {
                                 resolvedValue = try expressionToPlainValue(value)
-                            } else if isAppleBuiltinRaw && Compiler.appleBuiltinPlainKeys.contains(label) {
-                                // Raw Apple identifier with a known scalar key
-                                // (e.g. WFVariableName, Shell, InputMode, Script):
-                                // emit as plain value, not a tokenized text field.
+                            } else if Compiler.appleBuiltinPlainKeys.contains(plistKey) {
+                                // Apple plist keys that must be plain strings
+                                // (variable names, shell choice, script body,
+                                // comment text, etc.), regardless of whether the
+                                // action came from the registry or a raw identifier.
                                 resolvedValue = try expressionToPlainValue(value)
                             } else {
                                 resolvedValue = try expressionToValueWithOutputMap(value, outputMap: outputMap)
                             }
 
-                            // For built-in actions, map friendly name to plist key
-                            let plistKey = paramDef?.key ?? label
                             params[plistKey] = resolvedValue
                             continue
                         }

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -358,7 +358,8 @@ struct Compiler: Sendable {
         "Shell",
         "InputMode",
         "Script",
-        "WFTextActionText"
+        "WFTextActionText",
+        "WFNotificationActionTitle"
     ]
 
     private static let defaultInputContentClasses: [String] = [
@@ -399,18 +400,53 @@ struct Compiler: Sendable {
     }
 
     private func parseNoInputDirective(value: String, location: SourceLocation) throws -> [String: Any] {
-        let v = value.trimmingCharacters(in: .whitespaces).lowercased()
-        switch v {
+        // Accept either a single keyword ("ask", "clipboard", "continue",
+        // "cancel") or a two-word form for "ask" with a content type
+        // ("ask files", "ask images", "ask media", "ask url", "ask text",
+        // "ask contact", "ask date", "ask number"). The two-word form
+        // tells Shortcuts.app what picker to present when the user runs
+        // the shortcut with no input.
+        let parts = value.lowercased().split(whereSeparator: { ", :".contains($0) }).map(String.init).filter { !$0.isEmpty }
+        guard let head = parts.first else {
+            throw CompilerError(message: "Empty #noinput directive", location: location)
+        }
+        switch head {
         case "continue":
             return ["Name": "WFWorkflowNoInputBehaviorContinueWithInput", "Parameters": [String: Any]()]
-        case "ask", "askforinput":
-            return ["Name": "WFWorkflowNoInputBehaviorAskForInput", "Parameters": [String: Any]()]
         case "clipboard", "getclipboard":
             return ["Name": "WFWorkflowNoInputBehaviorGetClipboard", "Parameters": [String: Any]()]
         case "cancel":
             return ["Name": "WFWorkflowNoInputBehaviorReturnToHomeScreen", "Parameters": [String: Any]()]
+        case "ask", "askforinput":
+            var parameters: [String: Any] = [:]
+            if parts.count > 1 {
+                let typeMap: [String: (String, String)] = [
+                    // input type token -> (ItemClass, WFPickingMode)
+                    "files": ("WFGenericFileContentItem", "Files"),
+                    "file": ("WFGenericFileContentItem", "Files"),
+                    "images": ("WFImageContentItem", "Photos"),
+                    "image": ("WFImageContentItem", "Photos"),
+                    "photos": ("WFImageContentItem", "Photos"),
+                    "media": ("WFAVAssetContentItem", "Media"),
+                    "video": ("WFAVAssetContentItem", "Media"),
+                    "url": ("WFURLContentItem", "URL"),
+                    "text": ("WFStringContentItem", "Text"),
+                    "string": ("WFStringContentItem", "Text"),
+                    "contact": ("WFContactContentItem", "Contact"),
+                    "date": ("WFDateContentItem", "Date"),
+                    "number": ("WFNumberContentItem", "Number")
+                ]
+                let token = parts[1]
+                guard let (itemClass, pickingMode) = typeMap[token] else {
+                    let valid = typeMap.keys.sorted().joined(separator: ", ")
+                    throw CompilerError(message: "Unknown ask type '\(token)' in #noinput. Valid: \(valid)", location: location)
+                }
+                parameters["ItemClass"] = itemClass
+                parameters["SerializedParameters"] = ["WFPickingMode": pickingMode]
+            }
+            return ["Name": "WFWorkflowNoInputBehaviorAskForInput", "Parameters": parameters]
         default:
-            throw CompilerError(message: "Unknown #noinput value '\(value)'. Valid: continue, ask, clipboard, cancel", location: location)
+            throw CompilerError(message: "Unknown #noinput value '\(value)'. Valid: continue, ask [type], clipboard, cancel", location: location)
         }
     }
 
@@ -566,7 +602,12 @@ struct Compiler: Sendable {
                     let pos = text.count
                     text += "\u{FFFC}"
                     let range = "{\(pos), 1}"
-                    if let ref = outputMap[name] {
+                    if name == "ShortcutInput" {
+                        // The shortcut input magic variable embedded inside
+                        // text uses the bare ExtensionInput token, same as
+                        // when it appears as a standalone field.
+                        attachments[range] = ["Type": "ExtensionInput"]
+                    } else if let ref = outputMap[name] {
                         attachments[range] = [
                             "OutputName": ref.name,
                             "OutputUUID": ref.uuid,

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -38,10 +38,20 @@ struct Compiler: Sendable {
         var iconColor = 463140863 // blue default
         var iconGlyph = 59771 // gear default
 
+        // Workflow surface toggles. Defaults preserve historical behavior:
+        // widget + watch on, no quick action / share sheet / menu bar.
+        var widgetEnabled = true
+        var watchEnabled = true
+        var quickActionEnabled = false
+        var shareSheetEnabled = false
+        var menuBarEnabled = false
+        // nil means "not set" -> use the full default content-class list.
+        var explicitInputClasses: [String]? = nil
+
         for node in nodes {
             switch node {
             case .importStatement: break // handled at validation
-            case .metadata(let key, let value, _):
+            case .metadata(let key, let value, let loc):
                 if key == "color", let color = registry.iconColors[value] {
                     iconColor = color
                 }
@@ -51,6 +61,24 @@ struct Compiler: Sendable {
                 }
                 if key == "name" {
                     shortcutName = value
+                }
+                if key == "input" {
+                    explicitInputClasses = try parseInputDirective(value: value, location: loc)
+                }
+                if key == "quickaction" {
+                    quickActionEnabled = parseBoolDirective(value)
+                }
+                if key == "sharesheet" {
+                    shareSheetEnabled = parseBoolDirective(value)
+                }
+                if key == "menubar" {
+                    menuBarEnabled = parseBoolDirective(value)
+                }
+                if key == "widget" {
+                    widgetEnabled = parseBoolDirective(value)
+                }
+                if key == "watch" {
+                    watchEnabled = parseBoolDirective(value)
                 }
             case .comment(let text, _):
                 actions.append(buildAction(
@@ -282,29 +310,98 @@ struct Compiler: Sendable {
                 "WFWorkflowIconStartColor": iconColor,
                 "WFWorkflowIconGlyphNumber": iconGlyph
             ],
-            "WFWorkflowTypes": ["NCWidget", "WatchKit"],
-            "WFWorkflowInputContentItemClasses": [
-                "WFAppStoreAppContentItem",
-                "WFArticleContentItem",
-                "WFContactContentItem",
-                "WFDateContentItem",
-                "WFEmailAddressContentItem",
-                "WFGenericFileContentItem",
-                "WFImageContentItem",
-                "WFiTunesProductContentItem",
-                "WFLocationContentItem",
-                "WFDCMapsLinkContentItem",
-                "WFAVAssetContentItem",
-                "WFPDFContentItem",
-                "WFPhoneNumberContentItem",
-                "WFRichTextContentItem",
-                "WFSafariWebPageContentItem",
-                "WFStringContentItem",
-                "WFURLContentItem"
-            ],
+            "WFWorkflowTypes": buildWorkflowTypes(
+                widget: widgetEnabled,
+                watch: watchEnabled,
+                quickAction: quickActionEnabled,
+                shareSheet: shareSheetEnabled,
+                menuBar: menuBarEnabled
+            ),
+            "WFWorkflowInputContentItemClasses": explicitInputClasses ?? defaultInputContentClasses,
+            "WFWorkflowHasShortcutInputVariables": (shareSheetEnabled || quickActionEnabled),
             "WFWorkflowActions": actions,
             "WFWorkflowName": shortcutName
         ]
+    }
+
+    private static let defaultInputContentClasses: [String] = [
+        "WFAppStoreAppContentItem",
+        "WFArticleContentItem",
+        "WFContactContentItem",
+        "WFDateContentItem",
+        "WFEmailAddressContentItem",
+        "WFGenericFileContentItem",
+        "WFImageContentItem",
+        "WFiTunesProductContentItem",
+        "WFLocationContentItem",
+        "WFDCMapsLinkContentItem",
+        "WFAVAssetContentItem",
+        "WFPDFContentItem",
+        "WFPhoneNumberContentItem",
+        "WFRichTextContentItem",
+        "WFSafariWebPageContentItem",
+        "WFStringContentItem",
+        "WFURLContentItem"
+    ]
+
+    private var defaultInputContentClasses: [String] { Compiler.defaultInputContentClasses }
+
+    private func buildWorkflowTypes(widget: Bool, watch: Bool, quickAction: Bool, shareSheet: Bool, menuBar: Bool) -> [String] {
+        var types: [String] = []
+        if widget { types.append("NCWidget") }
+        if watch { types.append("WatchKit") }
+        if quickAction { types.append("QuickActionsService") }
+        if shareSheet { types.append("ActionExtension") }
+        if menuBar { types.append("MenuBar") }
+        return types
+    }
+
+    private func parseBoolDirective(_ value: String) -> Bool {
+        let v = value.trimmingCharacters(in: .whitespaces).lowercased()
+        return v == "true" || v == "yes" || v == "1" || v == "on"
+    }
+
+    private func parseInputDirective(value: String, location: SourceLocation) throws -> [String] {
+        let normalized = value.lowercased().split(whereSeparator: { ", ".contains($0) })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        if normalized.isEmpty {
+            throw CompilerError(message: "#input directive needs at least one type (e.g. 'url', 'text', 'any', 'none')", location: location)
+        }
+        if normalized.contains("any") { return Compiler.defaultInputContentClasses }
+        if normalized.contains("none") { return [] }
+
+        let mapping: [String: [String]] = [
+            "url": ["WFURLContentItem", "WFSafariWebPageContentItem"],
+            "text": ["WFStringContentItem", "WFRichTextContentItem"],
+            "string": ["WFStringContentItem"],
+            "richtext": ["WFRichTextContentItem"],
+            "image": ["WFImageContentItem"],
+            "file": ["WFGenericFileContentItem", "WFPDFContentItem"],
+            "pdf": ["WFPDFContentItem"],
+            "media": ["WFAVAssetContentItem"],
+            "contact": ["WFContactContentItem"],
+            "location": ["WFLocationContentItem", "WFDCMapsLinkContentItem"],
+            "date": ["WFDateContentItem"],
+            "email": ["WFEmailAddressContentItem"],
+            "phone": ["WFPhoneNumberContentItem"],
+            "app": ["WFAppStoreAppContentItem", "WFiTunesProductContentItem"],
+            "article": ["WFArticleContentItem"]
+        ]
+
+        var result: [String] = []
+        var seen = Set<String>()
+        for token in normalized {
+            guard let classes = mapping[token] else {
+                let valid = mapping.keys.sorted().joined(separator: ", ")
+                throw CompilerError(message: "Unknown #input type '\(token)'. Valid: any, none, \(valid)", location: location)
+            }
+            for cls in classes where !seen.contains(cls) {
+                seen.insert(cls)
+                result.append(cls)
+            }
+        }
+        return result
     }
 
     // MARK: - Helpers

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -672,6 +672,14 @@ struct Compiler: Sendable {
     }
 
     private func iconGlyphNumber(for name: String) -> Int {
+        // Allow passing a raw glyph number directly: `#icon: 59693`.
+        // The named-glyph table below is a best-effort guess and several
+        // values do not match what current iOS/macOS Shortcuts actually
+        // renders. When the named lookup is wrong, fall back to a number
+        // copied from a real shortcut in ~/Library/Shortcuts/Shortcuts.sqlite.
+        if let n = Int(name.trimmingCharacters(in: .whitespaces)) {
+            return n
+        }
         let glyphs: [String: Int] = [
             "gear": 59771, "compose": 59772, "star": 59773,
             "heart": 59774, "bolt": 59775, "globe": 59776,

--- a/Sources/perspective-cuts/Parser/Parser.swift
+++ b/Sources/perspective-cuts/Parser/Parser.swift
@@ -104,6 +104,14 @@ struct Parser: Sendable {
                 valueParts.append(s)
                 pos += 1
                 continue
+            case .comma:
+                valueParts.append(",")
+                pos += 1
+                continue
+            case .boolLiteral(let b):
+                valueParts.append(b ? "true" : "false")
+                pos += 1
+                continue
             default:
                 break
             }


### PR DESCRIPTION
Hi! I've been using Perspective Cuts to author a few personal Shortcuts and ran into a handful of things that this PR addresses. Each commit is self-contained and they can be reviewed/merged independently. No tests added (the project has none yet) but I verified the output by diffing the binary plist of compiled shortcuts against shortcuts I'd built manually in Shortcuts.app for the same behaviour, and by importing the compiled output and exercising it via Share Sheet, Quick Action, and the file picker.

## Features

### `Add workflow surface metadata directives`

Six new top-level metadata directives so a `.perspective` file can fully describe where a shortcut appears (Share Sheet, Quick Actions, menu bar, widget, watch) and which content types it accepts as input. Previously these had to be set manually in Shortcuts.app after import.

| Directive | Effect |
|---|---|
| `#input: <type>[, <type>...]` | Sets `WFWorkflowInputContentItemClasses` (filter what's accepted as input) |
| `#quickaction: true\|false` | Adds `QuickActionsService` to `WFWorkflowTypes` |
| `#sharesheet: true\|false` | Adds `ActionExtension` to `WFWorkflowTypes` |
| `#menubar: true\|false` | Adds `MenuBar` to `WFWorkflowTypes` |
| `#widget: true\|false` | Toggles `NCWidget` (default on) |
| `#watch: true\|false` | Toggles `WatchKit` (default on) |

`#input` accepts comma- or space-separated type tokens (`url`, `text`, `image`, `file`, `media`, `contact`, `location`, `date`, `email`, `phone`, `app`, `article`, `pdf`, `string`, `richtext`) plus the special tokens `any` (default list) and `none` (empty list). When `#sharesheet` or `#quickaction` is enabled, `WFWorkflowHasShortcutInputVariables` is set to `true` automatically.

Parser change: `parseMetadata` now also accepts `comma` and `boolLiteral` tokens inside metadata values so directives like `#input: url, text` and `#sharesheet: true` parse cleanly. No new lexer or AST changes were required.

### `Fix raw is.workflow.actions.* calls and add #noinput, --open`

Adds `#noinput: continue|ask|clipboard|cancel` (and a two-word form `ask <type>` introduced later in the PR for picker types) which emits `WFWorkflowNoInputBehavior` so the shortcut header in Shortcuts.app shows the inline "If there's no input" fallback instead of needing a manual check.

Adds `compile --open`: after signing, automatically `open` the resulting `.shortcut` so Shortcuts.app picks up the import dialog. Combine with `--sign`. (Subsequent updates can use the existing `--install` flag.)

### `Allow raw glyph numbers in #icon directive`

`#icon: 59693` now works (raw `WFWorkflowIconGlyphNumber`). The named-glyph table in `iconGlyphNumber(for:)` has several values that don't match what current iOS/macOS Shortcuts renders — the named lookup is kept as-is, but users can now copy a known-good number directly from `~/Library/Shortcuts/Shortcuts.sqlite` (`ZSHORTCUTICON.ZGLYPHNUMBER`) when they hit a stale mapping.

### `Extend #noinput ask with picker types; ShortcutInput in interpolation`

`#noinput: ask <type>` selects the picker Shortcuts.app presents when the user runs the shortcut with no input (`files`, `images`, `media`, `url`, `text`, `contact`, `date`, `number`). Maps to `WFWorkflowNoInputBehaviorAskForInput` with `Parameters.ItemClass` and `Parameters.SerializedParameters.WFPickingMode` set per Apple's expected values.

`ShortcutInput` referenced inside an interpolated string (e.g. `"\(ShortcutInput)"` inside a notification body) now serialises as the `ExtensionInput` token, not as a regular named-variable reference. Bare references already worked; this aligns interpolation with that.

`WFNotificationActionTitle` added to `appleBuiltinPlainKeys` so plain strings remain plain in notification titles.

## Bug fixes

### `Fix raw is.workflow.actions.* calls`

When an action was called by raw identifier (e.g. `is.workflow.actions.runshellscript(Input: someVar)`) the compiler took the 3rd-party path because the heuristic for "third party" was simply "name contains a dot". That path called `expressionToPlainValue` which does not consult the `outputMap`, so any variable reference passed in as an argument was serialised as a bare string and the resulting shortcut showed disconnected boxes (no vertical line between the producer and the consumer in Shortcuts.app).

Fix: identifiers in the `is.workflow.actions.` namespace are now treated as built-in even when the registry does not know about them. Real 3rd-party identifiers (e.g. `com.openai.chat.AskIntent`) still take the App Intent path.

### `Force plain-string serialisation for known scalar plist keys`

Built-in actions whose parameter type is the generic `string` (e.g. `setVariable`'s `name` -> `WFVariableName`) were being serialised as `WFTextTokenString` envelopes because the type whitelist for plain emission only covered `enum`, `boolean`, and `plainString`. Shortcuts.app then rendered a placeholder ("Variable Name") for the field instead of the literal value.

Fix: resolve the plist key first, then check it against `appleBuiltinPlainKeys` regardless of whether the action is a registry built-in or a raw `is.workflow.actions.*` call. Keys covered: `WFVariableName`, `WFCommentActionText`, `Shell`, `InputMode`, `Script`, `WFTextActionText`, `WFNotificationActionTitle`.

### `Fix Magic Variable serialisation and NoInputBehavior values`

Three issues that caused Shortcuts.app to render disconnected action boxes (no vertical line between producer and consumer) and to ignore the `#noinput` directive entirely. Diagnosed by extracting and inspecting the binary plist of a real Apple shortcut with the desired behaviour.

1. Bare variable references (where the entire field IS the variable, not text containing it) must be serialised as `WFTextTokenAttachment` with the attachment descriptor at the top of `Value` — not as `WFTextTokenString` with a placeholder character and an `attachmentsByRange` map. The previous form is valid for interpolated text but Shortcuts.app does not draw the connection line for it.
2. The identifier `ShortcutInput` in source now maps to Apple's `ExtensionInput` token (`{Type: ExtensionInput}`), the magic variable that represents whatever was passed in via Share Sheet, Quick Action or run input.
3. `WFWorkflowNoInputBehavior`'s `Name` value requires the `WFWorkflowNoInputBehavior` prefix (e.g. `WFWorkflowNoInputBehaviorGetClipboard`), not the bare suffix. Without the prefix Shortcuts.app silently ignored the key and fell back to "Continue".

## Notes

Happy to split this into multiple smaller PRs if you'd prefer; just let me know.