### PR TITLE
Fix splitText/combineText custom separator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# perspective-cuts
+
+A text-based Apple Shortcuts compiler.
+
+## Rules
+
+- **Always open SQLite databases read-only** (`SQLITE_OPEN_READONLY` / `sqlite3_open_v2` with read-only flag). Never open with write access unless the operation explicitly requires it (e.g., `--install` writing to the Shortcuts database).

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -54,7 +54,7 @@ These go at the top of your file after the import.
 
 `#color: purple` sets the icon background. Options: red, orange, yellow, green, teal, lightBlue, blue, darkBlue, purple, pink, darkPink, gray.
 
-`#icon: compose` sets the icon glyph. Options: gear, compose, star, heart, bolt, globe, mic, music, play, camera, photo, film, mail, message, phone, clock, alarm, calendar, map, location, bookmark, tag, folder, doc, list, cart, bag, gift, lock, key, link, flag, bell, eye, hand, person, house, car, airplane, sun, moon, cloud, umbrella, flame, drop, leaf, paintbrush, pencil, scissors, wand, cube, download, upload, share, trash, magnifyingglass.
+`#icon: compose` sets the icon glyph. Options: gear, compose, star, heart, bolt, globe, mic, music, play, camera, photo, film, mail, message, phone, clock, alarm, calendar, map, location, bookmark, tag, folder, doc, list, cart, bag, gift, lock, key, link, flag, bell, eye, hand, person, house, car, airplane, sun, moon, cloud, umbrella, flame, drop, leaf, paintbrush, pencil, scissors, wand, cube, download, upload, share, trash, magnifyingglass, robot.
 
 `#name: My Shortcut` sets the display name. Supports multiple words and apostrophes.
 

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -336,6 +336,8 @@ For third party apps, use the full identifier with dots: `com.openai.chat.AskInt
 
 The `case` keyword is reserved. The `changeCase` action cannot be used until the parser is updated. Use `useModel` as a workaround.
 
+For multi-file shortcuts, use `#include "path/to/fragment.perspective"` to inline other files. Mark non-standalone files with `#fragment`. Include paths are relative to the including file. The compiler strips imports and metadata from included files automatically.
+
 Compile with `perspective-cuts compile --sign file.perspective`. Always use `--sign` for importable shortcuts.
 
 ## Tutorials
@@ -560,6 +562,62 @@ getWiFiNetwork() -> wifi
 getDeviceDetail(detail: "Device Name") -> device
 showResult(text: "Device: \(device)\nIP: \(ip)\nWi-Fi: \(wifi)")
 ```
+
+## Fragment Composition
+
+Perspective supports splitting shortcuts across multiple files using `#include`. This lets you break large shortcuts into smaller, independently testable pieces and compose them into a single compiled shortcut.
+
+### Basic Include
+
+```
+import Shortcuts
+#name: My Shortcut
+
+#include "fragments/config-loader.perspective"
+#include "fragments/main-loop.perspective"
+```
+
+The compiler resolves `#include` directives at compile time. It reads the referenced file, strips any `import Shortcuts` statements and metadata (`#name`, `#color`, `#icon`), and inlines the remaining actions at the include site. The result is a single flat shortcut.
+
+Include paths are resolved relative to the including file's directory. If your main file is at `project/main.perspective` and it includes `"fragments/helper.perspective"`, the compiler looks for `project/fragments/helper.perspective`.
+
+### Fragment Files
+
+Mark a file with `#fragment` to indicate it is not intended to compile standalone:
+
+```
+#fragment
+// config-loader.perspective
+
+var apiKey = "sk-..."
+var serverURL = "https://api.example.com"
+```
+
+`#fragment` is documentation for the author. The compiler will error if you try to compile a `#fragment` file directly (`perspective compile fragments/config-loader.perspective`), but `#include` works on any `.perspective` file — fragment or not. You can include a standalone shortcut into another without editing it.
+
+### Multiple Fragments
+
+Fragments are inlined in order. Variables and action outputs from earlier includes are available to later ones:
+
+```
+import Shortcuts
+#name: Composed Shortcut
+
+#include "fragments/config.perspective"
+// config.perspective sets var apiKey, var serverURL
+
+#include "fragments/api-call.perspective"
+// api-call.perspective can reference apiKey and serverURL
+```
+
+### What Gets Stripped
+
+When a file is included, the compiler removes:
+- `import Shortcuts` statements
+- All metadata directives (`#name`, `#color`, `#icon`)
+- `#fragment` markers
+
+Everything else — actions, variables, comments, control flow — is inlined as-is.
 
 ## Understanding Variables
 

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -183,6 +183,13 @@ perspective-cuts validate --check-locked file.perspective
 
 The `--check-locked` flag queries Apple's ToolKit database to identify actions that require device unlock. It reports each action with its line number and branch context (e.g., "always reachable" vs "reachable when condition is true"). Requires the Shortcuts ToolKit database on your Mac.
 
+```bash
+# Check that shortcut has no external dependencies
+perspective-cuts validate --check-standalone file.perspective
+```
+
+The `--check-standalone` flag detects external dependencies: calls to other shortcuts via `runShortcut` and third-party app actions (dotted identifiers). Reports each dependency with line number and branch context. Useful for ensuring a shortcut can be shared or deployed independently.
+
 ## Built-in Actions
 
 167 verified actions organized by category. Parameters in parentheses are optional.

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -355,7 +355,7 @@ For third party apps, use the full identifier with dots: `com.openai.chat.AskInt
 
 The `case` keyword is reserved. The `changeCase` action cannot be used until the parser is updated. Use `useModel` as a workaround.
 
-For multi-file shortcuts, use `#include "path/to/fragment.perspective"` to inline other files. Mark non-standalone files with `#fragment`. Include paths are relative to the including file. The compiler strips imports and metadata from included files automatically. Use `#provides: var1, var2` and `#requires: var1` to declare fragment contracts — the compiler validates dependencies and auto-prefixes internal variables to prevent collisions.
+For multi-file shortcuts, use `#include "path/to/fragment.perspective"` to inline other files. Mark non-standalone files with `#fragment`. Include paths are relative to the including file. The compiler strips imports and metadata from included files automatically. Use `#provides: var1, var2` and `#requires: var1` to declare fragment contracts — the compiler validates dependencies and auto-prefixes internal variables to prevent collisions. Use `#requires fresh: var1` for variables that must be re-set before each include (the function-call pattern).
 
 Compile with `perspective-cuts compile --sign file.perspective`. Always use `--sign` for importable shortcuts.
 
@@ -657,6 +657,41 @@ var sessionId = "abc-123"
 The compiler validates that every `#requires` variable is in scope at the include site — whether from an earlier fragment's `#provides`, a `var` declaration in the main file, or a `->` capture in the main file.
 
 Two fragments providing the same variable name is a compile error.
+
+### Fresh Requirements
+
+Some fragments are used like functions — included multiple times with different inputs each time. For these, use `#requires fresh:` to ensure the caller sets the variable before *every* include, not just the first one.
+
+```
+// fragments/debug-write.perspective
+#fragment
+#requires: debugLogPath
+#requires fresh: debugLine
+
+if debugEnabled == "true" {
+    appendToFile(input: debugLine, path: debugLogPath, newLine: true)
+}
+```
+
+```
+// main.perspective
+import Shortcuts
+#name: Debug Example
+
+var debugLogPath = "/tmp/debug.log"
+
+var debugLine = "starting up"
+#include "fragments/debug-write.perspective"
+
+var debugLine = "processing complete"
+#include "fragments/debug-write.perspective"
+```
+
+The `debugLogPath` variable is config-like — set once and used by every include. The `debugLine` variable is parameter-like — it needs a fresh value each time. Without `#requires fresh:`, forgetting to re-set `debugLine` before the second include would silently use the stale value. With it, the compiler catches the mistake.
+
+After each `#include`, fresh-required variables are cleared from the "recently assigned" set. The caller must assign them again before the next include of any fragment that requires them fresh.
+
+You can mix `#requires:` and `#requires fresh:` in the same fragment. Regular `#requires` just checks that the variable exists in scope. `#requires fresh:` additionally checks that it was assigned since the last `#include`.
 
 ### Variable Auto-Prefixing
 

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -190,6 +190,13 @@ perspective-cuts validate --check-standalone file.perspective
 
 The `--check-standalone` flag detects external dependencies: calls to other shortcuts via `runShortcut` and third-party app actions (dotted identifiers). Reports each dependency with line number and branch context. Useful for ensuring a shortcut can be shared or deployed independently.
 
+```bash
+# Check for potential Siri timeout issues
+perspective-cuts validate --check-siri file.perspective
+```
+
+The `--check-siri` flag warns when a potentially slow action (network requests, location lookups, AI model calls, etc.) appears on a code path without a preceding output-producing action. Shortcuts invoked via "Hey Siri" error out if no output is produced within ~4-5 seconds. This is a heuristic check — false positives are expected.
+
 ## Built-in Actions
 
 167 verified actions organized by category. Parameters in parentheses are optional.

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -336,7 +336,7 @@ For third party apps, use the full identifier with dots: `com.openai.chat.AskInt
 
 The `case` keyword is reserved. The `changeCase` action cannot be used until the parser is updated. Use `useModel` as a workaround.
 
-For multi-file shortcuts, use `#include "path/to/fragment.perspective"` to inline other files. Mark non-standalone files with `#fragment`. Include paths are relative to the including file. The compiler strips imports and metadata from included files automatically.
+For multi-file shortcuts, use `#include "path/to/fragment.perspective"` to inline other files. Mark non-standalone files with `#fragment`. Include paths are relative to the including file. The compiler strips imports and metadata from included files automatically. Use `#provides: var1, var2` and `#requires: var1` to declare fragment contracts — the compiler validates dependencies and auto-prefixes internal variables to prevent collisions.
 
 Compile with `perspective-cuts compile --sign file.perspective`. Always use `--sign` for importable shortcuts.
 
@@ -610,14 +610,58 @@ import Shortcuts
 // api-call.perspective can reference apiKey and serverURL
 ```
 
+### Dependency Contracts: `#provides` and `#requires`
+
+Fragments can declare what variables they export and depend on:
+
+```
+// fragments/config-loader.perspective
+#fragment
+#provides: apiKey, serverURL, deviceId
+
+var apiKey = "sk-..."
+var serverURL = "https://api.example.com"
+getDeviceDetail(detail: "Device Name") -> deviceId
+```
+
+```
+// fragments/session-setup.perspective
+#fragment
+#requires: serverURL
+#provides: sessionId
+
+var temp = "working..."
+// ... uses serverURL, sets sessionId ...
+var sessionId = "abc-123"
+```
+
+The compiler validates that every `#requires` variable is in scope at the include site — whether from an earlier fragment's `#provides`, a `var` declaration in the main file, or a `->` capture in the main file.
+
+Two fragments providing the same variable name is a compile error.
+
+### Variable Auto-Prefixing
+
+When a fragment declares `#provides` or `#requires`, all variables NOT listed in those declarations are considered internal. The compiler rewrites internal variable names with a prefix derived from the filename to prevent collisions between fragments.
+
+For example, if `config-loader.perspective` has an internal `var temp`, it becomes `configLoader__temp` in the compiled output. Provided variables like `apiKey` keep their original names.
+
+This means fragment authors write natural code without worrying about namespace collisions. Two fragments can both use `var temp` internally and they will not conflict.
+
+Variables exempt from prefixing:
+- Variables listed in `#provides` (they are the public API)
+- Variables listed in `#requires` (they come from outside the fragment)
+- For-each loop iterator variables (they map to Shortcuts' "Repeat Item" at runtime)
+
+Fragments without any `#provides` or `#requires` declarations are not prefixed. This keeps simple fragments and included standalone files working as-is.
+
 ### What Gets Stripped
 
 When a file is included, the compiler removes:
 - `import Shortcuts` statements
 - All metadata directives (`#name`, `#color`, `#icon`)
-- `#fragment` markers
+- `#fragment`, `#provides`, and `#requires` declarations
 
-Everything else — actions, variables, comments, control flow — is inlined as-is.
+Everything else — actions, variables, comments, control flow — is inlined (with auto-prefixing applied if the fragment has contracts).
 
 ## Understanding Variables
 

--- a/PERSPECTIVE-LANGUAGE.md
+++ b/PERSPECTIVE-LANGUAGE.md
@@ -176,7 +176,12 @@ perspective-cuts discover --third-party
 
 # Validate without compiling
 perspective-cuts validate file.perspective
+
+# Check that shortcut works on a locked device
+perspective-cuts validate --check-locked file.perspective
 ```
+
+The `--check-locked` flag queries Apple's ToolKit database to identify actions that require device unlock. It reports each action with its line number and branch context (e.g., "always reachable" vs "reachable when condition is true"). Requires the Shortcuts ToolKit database on your Mac.
 
 ## Built-in Actions
 

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
-            exclude: ["Resources"]
+            resources: [.copy("Resources/actions.json")]
         ),
         .testTarget(
             name: "perspective-cutsTests",

--- a/Package.swift
+++ b/Package.swift
@@ -15,5 +15,10 @@ let package = Package(
             ],
             exclude: ["Resources"]
         ),
+        .testTarget(
+            name: "perspective-cutsTests",
+            dependencies: ["perspective-cuts"],
+            path: "Tests"
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ perspective-cuts detail com.openai.chat.AskIntent   # Inspect action parameters
 perspective-cuts validate file.perspective           # Validate syntax
 perspective-cuts validate --check-locked file.perspective  # Check lock-screen compatibility
 perspective-cuts validate --check-standalone file.perspective  # Check for external dependencies
+perspective-cuts validate --check-siri file.perspective        # Check for Siri timeout issues
 ```
 
 ## macOS Only

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ perspective-cuts discover openai                     # Find third party actions
 perspective-cuts discover --third-party              # All third party apps
 perspective-cuts detail com.openai.chat.AskIntent   # Inspect action parameters
 perspective-cuts validate file.perspective           # Validate syntax
+perspective-cuts validate --check-locked file.perspective  # Check lock-screen compatibility
 ```
 
 ## macOS Only

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Other tools existed for writing shortcuts as code. JellyCuts was the main one. B
 - Apple Intelligence with Private Cloud Compute and on-device models
 - Translation to 21 languages
 - Control flow (if/else, repeat, for-each, menu)
+- Fragment composition (`#include`) for multi-file shortcuts
 - Compiles to signed `.shortcut` files that work on macOS, iOS, and iPadOS
 - `discover` command to find actions from any installed app
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ perspective-cuts discover --third-party              # All third party apps
 perspective-cuts detail com.openai.chat.AskIntent   # Inspect action parameters
 perspective-cuts validate file.perspective           # Validate syntax
 perspective-cuts validate --check-locked file.perspective  # Check lock-screen compatibility
+perspective-cuts validate --check-standalone file.perspective  # Check for external dependencies
 ```
 
 ## macOS Only

--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -44,14 +44,23 @@ struct Compile: ParsableCommand {
         let toolKitReader = try? Self.openToolKitDB()
         let plist = try Compiler(registry: registry, toolKitReader: toolKitReader).compile(nodes: nodes)
 
-        // Determine output path
-        let baseName = inputURL.deletingPathExtension().lastPathComponent
-        let outputPath = output ?? "\(baseName).shortcut"
-        let outputURL = URL(fileURLWithPath: outputPath)
-
         // Extract actions and name for install mode
         let actions = plist["WFWorkflowActions"] as? [[String: Any]] ?? []
+        let baseName = inputURL.deletingPathExtension().lastPathComponent
         let shortcutName = plist["WFWorkflowName"] as? String ?? baseName
+
+        // Determine output path. Precedence (last wins):
+        //   1. Input filename stem          (default)
+        //   2. #name: directive             (if present)
+        //   3. -o / --output                (if present)
+        // The Shortcuts app names imported shortcuts from the .shortcut filename,
+        // not the WFWorkflowName in the plist, so we need the filename to match.
+        let explicitName: String? = nodes.compactMap { node -> String? in
+            if case .metadata(let key, let value, _) = node, key == "name" { return value }
+            return nil
+        }.first
+        let outputPath = output ?? "\(explicitName ?? baseName).shortcut"
+        let outputURL = URL(fileURLWithPath: outputPath)
 
         // Serialize to binary plist
         let data = try PropertyListSerialization.data(

--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -157,6 +157,9 @@ struct Validate: ParsableCommand {
     @Flag(name: .long, help: "Check that the shortcut works on a locked device")
     var checkLocked: Bool = false
 
+    @Flag(name: .long, help: "Check that the shortcut has no external dependencies (other shortcuts or 3rd-party apps)")
+    var checkStandalone: Bool = false
+
     func run() throws {
         let url = URL(fileURLWithPath: file)
         guard FileManager.default.fileExists(atPath: url.path) else {
@@ -176,6 +179,20 @@ struct Validate: ParsableCommand {
             try validateNode(node, registry: registry)
         }
 
+        var hasErrors = false
+
+        if checkStandalone {
+            let analyzer = StandaloneAnalyzer(registry: registry)
+            let diagnostics = analyzer.analyze(nodes: nodes)
+            if !diagnostics.isEmpty {
+                FileHandle.standardError.write(Data("error: shortcut has external dependencies:\n".utf8))
+                for diag in diagnostics {
+                    FileHandle.standardError.write(Data("  \(diag)\n".utf8))
+                }
+                hasErrors = true
+            }
+        }
+
         if checkLocked {
             guard let toolKitReader = try? Compile.openToolKitDB() else {
                 FileHandle.standardError.write(Data("warning: ToolKit database not found — cannot verify lock-screen compatibility\n".utf8))
@@ -189,8 +206,12 @@ struct Validate: ParsableCommand {
                 for diag in diagnostics {
                     FileHandle.standardError.write(Data("  \(diag)\n".utf8))
                 }
-                throw ExitCode.failure
+                hasErrors = true
             }
+        }
+
+        if hasErrors {
+            throw ExitCode.failure
         }
 
         print("Valid. \(nodes.count) statements parsed.")

--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -160,6 +160,9 @@ struct Validate: ParsableCommand {
     @Flag(name: .long, help: "Check that the shortcut has no external dependencies (other shortcuts or 3rd-party apps)")
     var checkStandalone: Bool = false
 
+    @Flag(name: .long, help: "Check for potential Siri timeout issues (slow actions without prior output)")
+    var checkSiri: Bool = false
+
     func run() throws {
         let url = URL(fileURLWithPath: file)
         guard FileManager.default.fileExists(atPath: url.path) else {
@@ -186,6 +189,18 @@ struct Validate: ParsableCommand {
             let diagnostics = analyzer.analyze(nodes: nodes)
             if !diagnostics.isEmpty {
                 FileHandle.standardError.write(Data("error: shortcut has external dependencies:\n".utf8))
+                for diag in diagnostics {
+                    FileHandle.standardError.write(Data("  \(diag)\n".utf8))
+                }
+                hasErrors = true
+            }
+        }
+
+        if checkSiri {
+            let analyzer = SiriTimeoutAnalyzer(registry: registry)
+            let diagnostics = analyzer.analyze(nodes: nodes)
+            if !diagnostics.isEmpty {
+                FileHandle.standardError.write(Data("warning: shortcut may trigger Siri timeout:\n".utf8))
                 for diag in diagnostics {
                     FileHandle.standardError.write(Data("  \(diag)\n".utf8))
                 }

--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -172,9 +172,28 @@ struct Validate: ParsableCommand {
         let tokens = try Lexer(source: source).tokenize()
         let parsedNodes = try Parser(tokens: tokens).parse()
 
-        // Resolve #include directives before validation
-        let sourceDir = url.deletingLastPathComponent()
-        let nodes = try Preprocessor(sourceDirectory: sourceDir).preprocess(nodes: parsedNodes)
+        // For fragment files, skip the preprocessor (which rejects #fragment
+        // files) and run analyzers directly on the filtered parsed nodes.
+        let isFragment = parsedNodes.contains(where: {
+            if case .fragmentMarker = $0 { return true } else { return false }
+        })
+
+        let nodes: [ASTNode]
+        if isFragment {
+            nodes = parsedNodes.filter { node in
+                switch node {
+                case .importStatement, .metadata, .fragmentMarker,
+                     .providesDeclaration, .requiresDeclaration, .includeDirective:
+                    return false
+                default:
+                    return true
+                }
+            }
+        } else {
+            // Resolve #include directives before validation
+            let sourceDir = url.deletingLastPathComponent()
+            nodes = try Preprocessor(sourceDirectory: sourceDir).preprocess(nodes: parsedNodes)
+        }
 
         // Validate action names against registry
         let registry = try ActionRegistry.load()

--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -154,6 +154,9 @@ struct Validate: ParsableCommand {
     @Argument(help: "The .perspective file to validate")
     var file: String
 
+    @Flag(name: .long, help: "Check that the shortcut works on a locked device")
+    var checkLocked: Bool = false
+
     func run() throws {
         let url = URL(fileURLWithPath: file)
         guard FileManager.default.fileExists(atPath: url.path) else {
@@ -171,6 +174,23 @@ struct Validate: ParsableCommand {
         let registry = try ActionRegistry.load()
         for node in nodes {
             try validateNode(node, registry: registry)
+        }
+
+        if checkLocked {
+            guard let toolKitReader = try? Compile.openToolKitDB() else {
+                FileHandle.standardError.write(Data("warning: ToolKit database not found — cannot verify lock-screen compatibility\n".utf8))
+                print("Valid. \(nodes.count) statements parsed.")
+                return
+            }
+            let analyzer = LockAnalyzer(registry: registry, policyProvider: toolKitReader)
+            let diagnostics = analyzer.analyze(nodes: nodes)
+            if !diagnostics.isEmpty {
+                FileHandle.standardError.write(Data("error: shortcut may require device unlock:\n".utf8))
+                for diag in diagnostics {
+                    FileHandle.standardError.write(Data("  \(diag)\n".utf8))
+                }
+                throw ExitCode.failure
+            }
         }
 
         print("Valid. \(nodes.count) statements parsed.")
@@ -478,6 +498,22 @@ final class ToolKitReader: @unchecked Sendable {
             map[p.key] = p
         }
         return map
+    }
+
+    // MARK: - Authentication Policy
+
+    /// Returns the authenticationPolicy for an action, e.g. "none",
+    /// "requiresAuthenticationOnOrigin", "requiresAuthenticationOnOriginAndRemote".
+    /// Returns nil if the action is not found in the ToolKit DB.
+    func getAuthenticationPolicy(identifier: String) -> String? {
+        var stmt: OpaquePointer?
+        let query = "SELECT authenticationPolicy FROM Tools WHERE id = ? LIMIT 1"
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, identifier, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              let cstr = sqlite3_column_text(stmt, 0) else { return nil }
+        return String(cString: cstr)
     }
 
     // MARK: - Discover (existing)

--- a/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
+++ b/Sources/perspective-cuts/CLI/PerspectiveCuts.swift
@@ -33,13 +33,18 @@ struct Compile: ParsableCommand {
     func run() throws {
         let source = try readSource(file)
         let tokens = try Lexer(source: source).tokenize()
-        let nodes = try Parser(tokens: tokens).parse()
+        let parsedNodes = try Parser(tokens: tokens).parse()
+
+        // Resolve #include directives before compilation
+        let inputURL = URL(fileURLWithPath: file)
+        let sourceDir = inputURL.deletingLastPathComponent()
+        let nodes = try Preprocessor(sourceDirectory: sourceDir).preprocess(nodes: parsedNodes)
+
         let registry = try ActionRegistry.load()
         let toolKitReader = try? Self.openToolKitDB()
         let plist = try Compiler(registry: registry, toolKitReader: toolKitReader).compile(nodes: nodes)
 
         // Determine output path
-        let inputURL = URL(fileURLWithPath: file)
         let baseName = inputURL.deletingPathExtension().lastPathComponent
         let outputPath = output ?? "\(baseName).shortcut"
         let outputURL = URL(fileURLWithPath: outputPath)
@@ -156,7 +161,11 @@ struct Validate: ParsableCommand {
         }
         let source = try String(contentsOf: url, encoding: .utf8)
         let tokens = try Lexer(source: source).tokenize()
-        let nodes = try Parser(tokens: tokens).parse()
+        let parsedNodes = try Parser(tokens: tokens).parse()
+
+        // Resolve #include directives before validation
+        let sourceDir = url.deletingLastPathComponent()
+        let nodes = try Preprocessor(sourceDirectory: sourceDir).preprocess(nodes: parsedNodes)
 
         // Validate action names against registry
         let registry = try ActionRegistry.load()

--- a/Sources/perspective-cuts/Compiler/ASTWalker.swift
+++ b/Sources/perspective-cuts/Compiler/ASTWalker.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Walks the AST tracking branch context, calling a visitor for each action encountered.
+/// Shared infrastructure for all static analyzers (lock check, standalone check, etc.).
+struct ASTWalker {
+
+    /// Info passed to the visitor for each action call encountered during the walk.
+    struct ActionVisit {
+        let name: String
+        let arguments: [(label: String?, value: Expression)]
+        let output: String?
+        let location: SourceLocation
+        let branchContext: String?
+    }
+
+    /// Walks the AST and calls `visitor` for each action call, passing branch context.
+    static func walk(nodes: [ASTNode], visitor: (ActionVisit) -> Void) {
+        walkNodes(nodes, branchContext: nil, visitor: visitor)
+    }
+
+    // MARK: - Private
+
+    private static func walkNodes(_ nodes: [ASTNode], branchContext: String?, visitor: (ActionVisit) -> Void) {
+        for node in nodes {
+            switch node {
+            case .actionCall(let name, let arguments, let output, let location):
+                visitor(ActionVisit(
+                    name: name,
+                    arguments: arguments,
+                    output: output,
+                    location: location,
+                    branchContext: branchContext
+                ))
+
+            case .ifStatement(let condition, let thenBody, let elseBody, _):
+                let condStr = describeCondition(condition)
+                walkNodes(thenBody, branchContext: composeContext(branchContext, "when \(condStr)"), visitor: visitor)
+                if let elseBody {
+                    walkNodes(elseBody, branchContext: composeContext(branchContext, "when not (\(condStr))"), visitor: visitor)
+                }
+
+            case .menu(let title, let cases, _):
+                for menuCase in cases {
+                    let caseContext = "in menu \"\(title)\" case \"\(menuCase.label)\""
+                    walkNodes(menuCase.body, branchContext: composeContext(branchContext, caseContext), visitor: visitor)
+                }
+
+            case .repeatLoop(_, let body, _):
+                walkNodes(body, branchContext: branchContext, visitor: visitor)
+
+            case .forEachLoop(_, _, let body, _):
+                walkNodes(body, branchContext: branchContext, visitor: visitor)
+
+            case .functionDeclaration(_, let body, _):
+                walkNodes(body, branchContext: branchContext, visitor: visitor)
+
+            default:
+                break
+            }
+        }
+    }
+
+    static func composeContext(_ existing: String?, _ new: String) -> String {
+        if let existing {
+            return "\(existing), \(new)"
+        }
+        return new
+    }
+
+    static func describeCondition(_ condition: Condition) -> String {
+        switch condition {
+        case .equals(let left, let right):
+            return "\(describeExpr(left)) == \(describeExpr(right))"
+        case .notEquals(let left, let right):
+            return "\(describeExpr(left)) != \(describeExpr(right))"
+        case .contains(let left, let right):
+            return "\(describeExpr(left)) contains \(describeExpr(right))"
+        case .greaterThan(let left, let right):
+            return "\(describeExpr(left)) > \(describeExpr(right))"
+        case .lessThan(let left, let right):
+            return "\(describeExpr(left)) < \(describeExpr(right))"
+        }
+    }
+
+    static func describeExpr(_ expr: Expression) -> String {
+        switch expr {
+        case .stringLiteral(let s): return "\"\(s)\""
+        case .numberLiteral(let n): return n.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(n)) : String(n)
+        case .boolLiteral(let b): return String(b)
+        case .variableReference(let v): return v
+        case .interpolatedString: return "<interpolated string>"
+        case .dictionaryLiteral: return "<dictionary>"
+        }
+    }
+}

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -41,13 +41,20 @@ struct Compiler: Sendable {
         ["Type": "ExtensionInput"]
     }
 
+    /// Maps user-chosen for-each loop variable names to the Shortcuts
+    /// runtime name "Repeat Item".
+    private static func resolveVariableName(_ name: String, forEachVars: Set<String>) -> String {
+        forEachVars.contains(name) ? "Repeat Item" : name
+    }
+
     func compile(nodes: [ASTNode]) throws -> [String: Any] {
         var outputMap: [String: OutputRef] = [:]
         var declaredVariables: Set<String> = [Self.shortcutInputName]
-        return try compileWithOutputMap(nodes: nodes, outputMap: &outputMap, declaredVariables: &declaredVariables)
+        var forEachVarNames: Set<String> = []
+        return try compileWithOutputMap(nodes: nodes, outputMap: &outputMap, declaredVariables: &declaredVariables, forEachVarNames: &forEachVarNames)
     }
 
-    private func compileWithOutputMap(nodes: [ASTNode], outputMap: inout [String: OutputRef], declaredVariables: inout Set<String>) throws -> [String: Any] {
+    private func compileWithOutputMap(nodes: [ASTNode], outputMap: inout [String: OutputRef], declaredVariables: inout Set<String>, forEachVarNames: inout Set<String>) throws -> [String: Any] {
         var actions: [[String: Any]] = []
         var shortcutName = "Perspective Shortcut"
         var iconColor = 463140863 // blue default
@@ -95,10 +102,10 @@ struct Compiler: Sendable {
                             "WFSerializationType": "WFTextTokenAttachment"
                         ]
                     } else {
-                        // Reference to a named variable (var varName = ...)
+                        // Reference to a named variable (var varName = ...) or for-each loop variable
                         wfInput = [
                             "Value": [
-                                "VariableName": refName,
+                                "VariableName": Self.resolveVariableName(refName, forEachVars: forEachVarNames),
                                 "Type": "Variable"
                             ] as [String: Any],
                             "WFSerializationType": "WFTextTokenAttachment"
@@ -115,7 +122,7 @@ struct Compiler: Sendable {
                     // For other expressions, emit a source action then set the variable to its output
                     let sourceAction: [String: Any]
                     if case .dictionaryLiteral = value {
-                        sourceAction = try buildDictionaryAction(from: value, outputMap: outputMap)
+                        sourceAction = try buildDictionaryAction(from: value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                     } else {
                         sourceAction = try buildTextAction(from: value)
                     }
@@ -220,17 +227,22 @@ struct Compiler: Sendable {
                                     ] as [String: Any]
                                 } else {
                                     resolvedValue = [
-                                        "Value": ["VariableName": varName, "Type": "Variable"],
+                                        "Value": ["VariableName": Self.resolveVariableName(varName, forEachVars: forEachVarNames), "Type": "Variable"],
                                         "WFSerializationType": "WFTextTokenAttachment"
                                     ] as [String: Any]
                                 }
                             } else {
-                                resolvedValue = try expressionToValueWithOutputMap(value, outputMap: outputMap)
+                                resolvedValue = try expressionToValueWithOutputMap(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                             }
 
                             // For built-in actions, map friendly name to plist key
                             let plistKey = paramDef?.key ?? label
                             params[plistKey] = resolvedValue
+                            // runShortcut needs both WFWorkflowName and WFWorkflow
+                            // for dynamic shortcut name resolution at runtime
+                            if plistKey == "WFWorkflowName" {
+                                params["WFWorkflow"] = resolvedValue
+                            }
                             continue
                         }
 
@@ -252,12 +264,12 @@ struct Compiler: Sendable {
                 let groupID = UUID().uuidString
                 // Emit conditional start
                 var condParams: [String: Any] = ["GroupingIdentifier": groupID, "WFControlFlowMode": 0]
-                try applyCondition(condition, to: &condParams, outputMap: outputMap)
+                try applyCondition(condition, to: &condParams, outputMap: outputMap, forEachVarNames: forEachVarNames)
                 actions.append(buildAction(identifier: "is.workflow.actions.conditional", parameters: condParams))
 
                 // Emit then body
                 for bodyNode in thenBody {
-                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
+                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables, forEachVarNames: &forEachVarNames)
                     if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                         actions.append(contentsOf: bodyActions)
                     }
@@ -270,7 +282,7 @@ struct Compiler: Sendable {
                         parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 1]
                     ))
                     for bodyNode in elseBody {
-                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
+                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables, forEachVarNames: &forEachVarNames)
                         if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                             actions.append(contentsOf: bodyActions)
                         }
@@ -291,7 +303,7 @@ struct Compiler: Sendable {
                     parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 0, "WFRepeatCount": countValue]
                 ))
                 for bodyNode in body {
-                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
+                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables, forEachVarNames: &forEachVarNames)
                     if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                         actions.append(contentsOf: bodyActions)
                     }
@@ -301,15 +313,45 @@ struct Compiler: Sendable {
                     parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 2]
                 ))
 
-            case .forEachLoop(_, let collection, let body, _):
+            case .forEachLoop(let itemName, let collection, let body, _):
                 let groupID = UUID().uuidString
-                let collectionValue = try expressionToValue(collection)
+                // WFInput for repeat-each needs WFTextTokenAttachment (direct
+                // variable reference), not WFTextTokenString.
+                let collectionValue: Any
+                if case .variableReference(let varName) = collection {
+                    if let ref = outputMap[varName] {
+                        collectionValue = [
+                            "Value": [
+                                "OutputUUID": ref.uuid,
+                                "Type": "ActionOutput",
+                                "OutputName": ref.name
+                            ],
+                            "WFSerializationType": "WFTextTokenAttachment"
+                        ] as [String: Any]
+                    } else if Self.isShortcutInput(varName) {
+                        collectionValue = [
+                            "Value": Self.extensionInputAttachment(),
+                            "WFSerializationType": "WFTextTokenAttachment"
+                        ] as [String: Any]
+                    } else {
+                        collectionValue = [
+                            "Value": ["VariableName": Self.resolveVariableName(varName, forEachVars: forEachVarNames), "Type": "Variable"],
+                            "WFSerializationType": "WFTextTokenAttachment"
+                        ] as [String: Any]
+                    }
+                } else {
+                    collectionValue = try expressionToValueWithOutputMap(collection, outputMap: outputMap, forEachVarNames: forEachVarNames)
+                }
                 actions.append(buildAction(
                     identifier: "is.workflow.actions.repeat.each",
                     parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 0, "WFInput": collectionValue]
                 ))
+                // Declare the loop variable so it can be referenced in the body.
+                // Shortcuts always calls this "Repeat Item" at runtime.
+                declaredVariables.insert(itemName)
+                forEachVarNames.insert(itemName)
                 for bodyNode in body {
-                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
+                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables, forEachVarNames: &forEachVarNames)
                     if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                         actions.append(contentsOf: bodyActions)
                     }
@@ -341,7 +383,7 @@ struct Compiler: Sendable {
                         ]
                     ))
                     for bodyNode in menuCase.body {
-                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
+                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables, forEachVarNames: &forEachVarNames)
                         if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                             actions.append(contentsOf: bodyActions)
                         }
@@ -400,8 +442,8 @@ struct Compiler: Sendable {
         ]
     }
 
-    private func buildDictionaryAction(from expression: Expression, outputMap: [String: OutputRef]) throws -> [String: Any] {
-        let value = try expressionToValueWithOutputMap(expression, outputMap: outputMap)
+    private func buildDictionaryAction(from expression: Expression, outputMap: [String: OutputRef], forEachVarNames: Set<String> = []) throws -> [String: Any] {
+        let value = try expressionToValueWithOutputMap(expression, outputMap: outputMap, forEachVarNames: forEachVarNames)
         let uuid = UUID().uuidString
         return buildAction(
             identifier: "is.workflow.actions.dictionary",
@@ -445,7 +487,7 @@ struct Compiler: Sendable {
         return try expressionToValueWithOutputMap(expr, outputMap: [:])
     }
 
-    private func expressionToValueWithOutputMap(_ expr: Expression, outputMap: [String: OutputRef]) throws -> Any {
+    private func expressionToValueWithOutputMap(_ expr: Expression, outputMap: [String: OutputRef], forEachVarNames: Set<String> = []) throws -> Any {
         switch expr {
         case .stringLiteral(let s):
             return [
@@ -473,7 +515,7 @@ struct Compiler: Sendable {
             }
             let attachment: [String: Any] = Self.isShortcutInput(name)
                 ? Self.extensionInputAttachment()
-                : ["VariableName": name, "Type": "Variable"]
+                : ["VariableName": Self.resolveVariableName(name, forEachVars: forEachVarNames), "Type": "Variable"]
             return [
                 "Value": [
                     "string": "\u{FFFC}",
@@ -503,7 +545,7 @@ struct Compiler: Sendable {
                     } else if Self.isShortcutInput(name) {
                         attachments[range] = Self.extensionInputAttachment()
                     } else {
-                        attachments[range] = ["VariableName": name, "Type": "Variable"]
+                        attachments[range] = ["VariableName": Self.resolveVariableName(name, forEachVars: forEachVarNames), "Type": "Variable"]
                     }
                 }
             }
@@ -515,7 +557,7 @@ struct Compiler: Sendable {
             var items: [[String: Any]] = []
             for entry in entries {
                 var item: [String: Any] = [:]
-                item["WFKey"] = try expressionToValueWithOutputMap(entry.key, outputMap: outputMap)
+                item["WFKey"] = try expressionToValueWithOutputMap(entry.key, outputMap: outputMap, forEachVarNames: forEachVarNames)
 
                 switch entry.value {
                 case .numberLiteral(let n):
@@ -533,10 +575,10 @@ struct Compiler: Sendable {
                     ] as [String: Any]
                 case .dictionaryLiteral:
                     item["WFItemType"] = 1
-                    item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap)
+                    item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                 default:
                     item["WFItemType"] = 0
-                    item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap)
+                    item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                 }
                 items.append(item)
             }
@@ -547,7 +589,7 @@ struct Compiler: Sendable {
         }
     }
 
-    private func applyCondition(_ condition: Condition, to params: inout [String: Any], outputMap: [String: OutputRef]) throws {
+    private func applyCondition(_ condition: Condition, to params: inout [String: Any], outputMap: [String: OutputRef], forEachVarNames: Set<String> = []) throws {
         // Helper: resolve the left-hand side of a condition.
         // Conditionals use a nested format for WFInput:
         //   { Type: "Variable", Variable: { Value: { ..., Aggrandizements: [coerce to string] }, WFSerializationType: "WFTextTokenAttachment" } }
@@ -584,7 +626,7 @@ struct Compiler: Sendable {
                     inner = [
                         "Value": [
                             "Aggrandizements": coercion,
-                            "VariableName": name,
+                            "VariableName": Self.resolveVariableName(name, forEachVars: forEachVarNames),
                             "Type": "Variable"
                         ] as [String: Any],
                         "WFSerializationType": "WFTextTokenAttachment"
@@ -595,7 +637,7 @@ struct Compiler: Sendable {
                     "Variable": inner
                 ] as [String: Any]
             }
-            return try expressionToValueWithOutputMap(expr, outputMap: outputMap)
+            return try expressionToValueWithOutputMap(expr, outputMap: outputMap, forEachVarNames: forEachVarNames)
         }
 
         switch condition {

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -235,6 +235,11 @@ struct Compiler: Sendable {
                                         "WFSerializationType": "WFTextTokenAttachment"
                                     ] as [String: Any]
                                 }
+                            } else if let paramType = paramDef?.type, paramType == "formDictionary",
+                                      case .dictionaryLiteral(let entries) = value {
+                                // Form dictionary: variable references become file items (WFItemType 5),
+                                // strings become text items (WFItemType 0).
+                                resolvedValue = try buildFormDictionary(entries: entries, outputMap: outputMap, forEachVarNames: forEachVarNames)
                             } else {
                                 resolvedValue = try expressionToValueWithOutputMap(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                             }
@@ -475,6 +480,58 @@ struct Compiler: Sendable {
             identifier: "is.workflow.actions.dictionary",
             parameters: ["WFItems": value, "UUID": uuid, "CustomOutputName": "Dictionary"]
         )
+    }
+
+    /// Builds a WFDictionaryFieldValue for form uploads.
+    /// Variable references become file items (WFItemType 5), everything else becomes text (WFItemType 0).
+    private func buildFormDictionary(entries: [DictionaryEntry], outputMap: [String: OutputRef], forEachVarNames: Set<String>) throws -> Any {
+        var items: [[String: Any]] = []
+        for entry in entries {
+            var item: [String: Any] = [:]
+            item["WFKey"] = try expressionToValueWithOutputMap(entry.key, outputMap: outputMap, forEachVarNames: forEachVarNames)
+
+            if case .variableReference(let varName) = entry.value {
+                // Variable reference → file item (WFItemType 5)
+                item["WFItemType"] = 5
+                let attachment: [String: Any]
+                if let ref = outputMap[varName] {
+                    attachment = [
+                        "Value": [
+                            "OutputUUID": ref.uuid,
+                            "Type": "ActionOutput",
+                            "OutputName": ref.name
+                        ] as [String: Any],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ]
+                } else if Self.isShortcutInput(varName) {
+                    attachment = [
+                        "Value": Self.extensionInputAttachment(),
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ]
+                } else {
+                    attachment = [
+                        "Value": [
+                            "VariableName": Self.resolveVariableName(varName, forEachVars: forEachVarNames),
+                            "Type": "Variable"
+                        ] as [String: Any],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ]
+                }
+                item["WFValue"] = [
+                    "Value": attachment,
+                    "WFSerializationType": "WFTokenAttachmentParameterState"
+                ] as [String: Any]
+            } else {
+                // String/other → text item (WFItemType 0)
+                item["WFItemType"] = 0
+                item["WFValue"] = try expressionToValueWithOutputMap(entry.value, outputMap: outputMap, forEachVarNames: forEachVarNames)
+            }
+            items.append(item)
+        }
+        return [
+            "Value": ["WFDictionaryFieldValueItems": items],
+            "WFSerializationType": "WFDictionaryFieldValue"
+        ] as [String: Any]
     }
 
     private func buildTextAction(from expression: Expression) throws -> [String: Any] {

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -235,6 +235,15 @@ struct Compiler: Sendable {
                                         "WFSerializationType": "WFTextTokenAttachment"
                                     ] as [String: Any]
                                 }
+                            } else if let paramType = paramDef?.type, paramType == "iCloudFolder" {
+                                // iCloudFolder: emit an implicit Text action with the
+                                // folder name string, then reference its output as a
+                                // WFTextTokenAttachment. This lets Shortcuts resolve
+                                // the iCloud Drive folder at runtime without embedding
+                                // device-specific bookmark UUIDs.
+                                let folderAction = try buildTextAction(from: value, outputMap: outputMap, forEachVarNames: forEachVarNames)
+                                actions.append(folderAction)
+                                resolvedValue = buildMagicVariable(outputOf: folderAction)
                             } else if let paramType = paramDef?.type, paramType == "formDictionary",
                                       case .dictionaryLiteral(let entries) = value {
                                 // Form dictionary: variable references become file items (WFItemType 5),

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -59,6 +59,7 @@ struct Compiler: Sendable {
         var shortcutName = "Perspective Shortcut"
         var iconColor = 463140863 // blue default
         var iconGlyph = 59771 // gear default
+        var noInputBehavior: String? = nil
 
         for node in nodes {
             switch node {
@@ -73,6 +74,9 @@ struct Compiler: Sendable {
                 }
                 if key == "name" {
                     shortcutName = value
+                }
+                if key == "noInputBehavior" {
+                    noInputBehavior = value
                 }
             case .comment(let text, _):
                 actions.append(buildAction(
@@ -409,7 +413,7 @@ struct Compiler: Sendable {
             }
         }
 
-        return [
+        var result: [String: Any] = [
             "WFWorkflowMinimumClientVersionString": "900",
             "WFWorkflowMinimumClientVersion": 900,
             "WFWorkflowClientVersion": "1200",
@@ -440,6 +444,19 @@ struct Compiler: Sendable {
             "WFWorkflowActions": actions,
             "WFWorkflowName": shortcutName
         ]
+
+        if let behavior = noInputBehavior {
+            let behaviorMap: [String: String] = [
+                "doNothing": "WFWorkflowNoInputBehaviorDoNothing",
+                "askForInput": "WFWorkflowNoInputBehaviorAskForInput",
+                "getClipboard": "WFWorkflowNoInputBehaviorGetClipboard",
+            ]
+            if let name = behaviorMap[behavior] {
+                result["WFWorkflowNoInputBehavior"] = ["Name": name, "Parameters": [:] as [String: Any]]
+            }
+        }
+
+        return result
     }
 
     // MARK: - Helpers
@@ -601,14 +618,14 @@ struct Compiler: Sendable {
     private func applyCondition(_ condition: Condition, to params: inout [String: Any], outputMap: [String: OutputRef], forEachVarNames: Set<String> = []) throws {
         // Helper: resolve the left-hand side of a condition.
         // Conditionals use a nested format for WFInput:
-        //   { Type: "Variable", Variable: { Value: { ..., Aggrandizements: [coerce to string] }, WFSerializationType: "WFTextTokenAttachment" } }
-        // The Aggrandizements coercion to WFStringContentItem is required
-        // so Shortcuts treats the value as a string before comparing.
-        func resolveInput(_ expr: Expression) throws -> Any {
+        //   { Type: "Variable", Variable: { Value: { ..., Aggrandizements: [coerce] }, WFSerializationType: "WFTextTokenAttachment" } }
+        // String comparisons (==, !=, contains) coerce to WFStringContentItem.
+        // Numeric comparisons (>, <) coerce to WFNumberContentItem.
+        func resolveInput(_ expr: Expression, coercionClass: String = "WFStringContentItem") throws -> Any {
             if case .variableReference(let name) = expr {
                 let coercion: [[String: Any]] = [
                     [
-                        "CoercionItemClass": "WFStringContentItem",
+                        "CoercionItemClass": coercionClass,
                         "Type": "WFCoercionVariableAggrandizement"
                     ]
                 ]
@@ -663,13 +680,13 @@ struct Compiler: Sendable {
             params["WFCondition"] = 99 // contains
             params["WFConditionalActionString"] = try expressionToPlainValue(right)
         case .greaterThan(let left, let right):
-            params["WFInput"] = try resolveInput(left)
+            params["WFInput"] = try resolveInput(left, coercionClass: "WFNumberContentItem")
             params["WFCondition"] = 2 // greater than
-            params["WFConditionalActionString"] = try expressionToPlainValue(right)
+            params["WFNumberValue"] = "\(try expressionToPlainValue(right))"
         case .lessThan(let left, let right):
-            params["WFInput"] = try resolveInput(left)
+            params["WFInput"] = try resolveInput(left, coercionClass: "WFNumberContentItem")
             params["WFCondition"] = 3 // less than
-            params["WFConditionalActionString"] = try expressionToPlainValue(right)
+            params["WFNumberValue"] = "\(try expressionToPlainValue(right))"
         }
     }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -27,9 +27,23 @@ struct Compiler: Sendable {
         let name: String
     }
 
+    /// Name of the built-in variable that references the Shortcut Input
+    /// (the value passed to a shortcut via `runShortcut(input:)`).
+    static let shortcutInputName = "shortcutInput"
+
+    /// Returns true when `name` refers to the Shortcut Input magic variable.
+    private static func isShortcutInput(_ name: String) -> Bool {
+        name == shortcutInputName
+    }
+
+    /// Builds the ExtensionInput attachment dict used wherever shortcutInput appears.
+    private static func extensionInputAttachment() -> [String: Any] {
+        ["Type": "ExtensionInput"]
+    }
+
     func compile(nodes: [ASTNode]) throws -> [String: Any] {
         var outputMap: [String: OutputRef] = [:]
-        var declaredVariables: Set<String> = []
+        var declaredVariables: Set<String> = [Self.shortcutInputName]
         return try compileWithOutputMap(nodes: nodes, outputMap: &outputMap, declaredVariables: &declaredVariables)
     }
 
@@ -70,6 +84,13 @@ struct Compiler: Sendable {
                                 "OutputUUID": ref.uuid,
                                 "Type": "ActionOutput",
                                 "OutputName": ref.name
+                            ] as [String: Any],
+                            "WFSerializationType": "WFTextTokenAttachment"
+                        ]
+                    } else if Self.isShortcutInput(refName) {
+                        wfInput = [
+                            "Value": [
+                                "Type": "ExtensionInput"
                             ] as [String: Any],
                             "WFSerializationType": "WFTextTokenAttachment"
                         ]
@@ -190,6 +211,11 @@ struct Compiler: Sendable {
                                             "Type": "ActionOutput",
                                             "OutputName": ref.name
                                         ],
+                                        "WFSerializationType": "WFTextTokenAttachment"
+                                    ] as [String: Any]
+                                } else if Self.isShortcutInput(varName) {
+                                    resolvedValue = [
+                                        "Value": Self.extensionInputAttachment(),
                                         "WFSerializationType": "WFTextTokenAttachment"
                                     ] as [String: Any]
                                 } else {
@@ -445,11 +471,14 @@ struct Compiler: Sendable {
                     "WFSerializationType": "WFTextTokenString"
                 ] as [String: Any]
             }
+            let attachment: [String: Any] = Self.isShortcutInput(name)
+                ? Self.extensionInputAttachment()
+                : ["VariableName": name, "Type": "Variable"]
             return [
                 "Value": [
                     "string": "\u{FFFC}",
                     "attachmentsByRange": [
-                        "{0, 1}": ["VariableName": name, "Type": "Variable"]
+                        "{0, 1}": attachment
                     ]
                 ],
                 "WFSerializationType": "WFTextTokenString"
@@ -471,6 +500,8 @@ struct Compiler: Sendable {
                             "OutputUUID": ref.uuid,
                             "Type": "ActionOutput"
                         ]
+                    } else if Self.isShortcutInput(name) {
+                        attachments[range] = Self.extensionInputAttachment()
                     } else {
                         attachments[range] = ["VariableName": name, "Type": "Variable"]
                     }
@@ -538,6 +569,14 @@ struct Compiler: Sendable {
                             "OutputUUID": ref.uuid,
                             "Type": "ActionOutput",
                             "OutputName": ref.name
+                        ] as [String: Any],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ] as [String: Any]
+                } else if Self.isShortcutInput(name) {
+                    inner = [
+                        "Value": [
+                            "Aggrandizements": coercion,
+                            "Type": "ExtensionInput"
                         ] as [String: Any],
                         "WFSerializationType": "WFTextTokenAttachment"
                     ] as [String: Any]

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -58,21 +58,53 @@ struct Compiler: Sendable {
                     parameters: ["WFCommentActionText": text]
                 ))
             case .variableDeclaration(let name, let value, _, _):
-                // Emit the appropriate action based on expression type
-                let sourceAction: [String: Any]
-                if case .dictionaryLiteral = value {
-                    sourceAction = try buildDictionaryAction(from: value, outputMap: outputMap)
+                // When the value is a bare variable reference, set directly without an intermediary action
+                if case .variableReference(let refName) = value {
+                    let wfInput: [String: Any]
+                    if let ref = outputMap[refName] {
+                        // Reference to an action output (-> varName)
+                        wfInput = [
+                            "Value": [
+                                "OutputUUID": ref.uuid,
+                                "Type": "ActionOutput",
+                                "OutputName": ref.name
+                            ] as [String: Any],
+                            "WFSerializationType": "WFTextTokenAttachment"
+                        ]
+                    } else {
+                        // Reference to a named variable (var varName = ...)
+                        wfInput = [
+                            "Value": [
+                                "VariableName": refName,
+                                "Type": "Variable"
+                            ] as [String: Any],
+                            "WFSerializationType": "WFTextTokenAttachment"
+                        ]
+                    }
+                    actions.append(buildAction(
+                        identifier: "is.workflow.actions.setvariable",
+                        parameters: [
+                            "WFVariableName": name,
+                            "WFInput": wfInput
+                        ]
+                    ))
                 } else {
-                    sourceAction = try buildTextAction(from: value)
+                    // For other expressions, emit a source action then set the variable to its output
+                    let sourceAction: [String: Any]
+                    if case .dictionaryLiteral = value {
+                        sourceAction = try buildDictionaryAction(from: value, outputMap: outputMap)
+                    } else {
+                        sourceAction = try buildTextAction(from: value)
+                    }
+                    actions.append(sourceAction)
+                    actions.append(buildAction(
+                        identifier: "is.workflow.actions.setvariable",
+                        parameters: [
+                            "WFVariableName": name,
+                            "WFInput": buildMagicVariable(outputOf: sourceAction)
+                        ]
+                    ))
                 }
-                actions.append(sourceAction)
-                actions.append(buildAction(
-                    identifier: "is.workflow.actions.setvariable",
-                    parameters: [
-                        "WFVariableName": name,
-                        "WFInput": buildMagicVariable(outputOf: sourceAction)
-                    ]
-                ))
             case .actionCall(let name, let arguments, let output, let location):
                 let def = registry.actions[name]
                 // If action contains dots, treat as raw identifier (3rd party app action)

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -142,6 +142,26 @@ struct Compiler: Sendable {
                                 resolvedValue = intVal
                             } else if let paramType = paramDef?.type, (paramType == "enum" || paramType == "boolean" || paramType == "plainString") {
                                 resolvedValue = try expressionToPlainValue(value)
+                            } else if let paramType = paramDef?.type, paramType == "variable",
+                                      case .variableReference(let varName) = value {
+                                // Variable-typed parameters need WFTextTokenAttachment,
+                                // not WFTextTokenString, so the action receives the
+                                // output directly rather than as interpolated text.
+                                if let ref = outputMap[varName] {
+                                    resolvedValue = [
+                                        "Value": [
+                                            "OutputUUID": ref.uuid,
+                                            "Type": "ActionOutput",
+                                            "OutputName": ref.name
+                                        ],
+                                        "WFSerializationType": "WFTextTokenAttachment"
+                                    ] as [String: Any]
+                                } else {
+                                    resolvedValue = [
+                                        "Value": ["VariableName": varName, "Type": "Variable"],
+                                        "WFSerializationType": "WFTextTokenAttachment"
+                                    ] as [String: Any]
+                                }
                             } else {
                                 resolvedValue = try expressionToValueWithOutputMap(value, outputMap: outputMap)
                             }

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -422,7 +422,7 @@ struct Compiler: Sendable {
                 throw CompilerError(message: "#fragment markers must be resolved by the preprocessor before compilation", location: location)
             case .providesDeclaration(_, let location):
                 throw CompilerError(message: "#provides declarations must be resolved by the preprocessor before compilation", location: location)
-            case .requiresDeclaration(_, let location):
+            case .requiresDeclaration(_, _, let location):
                 throw CompilerError(message: "#requires declarations must be resolved by the preprocessor before compilation", location: location)
             }
         }

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -397,6 +397,11 @@ struct Compiler: Sendable {
             case .functionDeclaration, .returnStatement:
                 // Functions are inlined at call sites (macro-style for now)
                 break
+
+            case .includeDirective(_, let location):
+                throw CompilerError(message: "#include directives must be resolved by the preprocessor before compilation", location: location)
+            case .fragmentMarker(let location):
+                throw CompilerError(message: "#fragment markers must be resolved by the preprocessor before compilation", location: location)
             }
         }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -29,10 +29,11 @@ struct Compiler: Sendable {
 
     func compile(nodes: [ASTNode]) throws -> [String: Any] {
         var outputMap: [String: OutputRef] = [:]
-        return try compileWithOutputMap(nodes: nodes, outputMap: &outputMap)
+        var declaredVariables: Set<String> = []
+        return try compileWithOutputMap(nodes: nodes, outputMap: &outputMap, declaredVariables: &declaredVariables)
     }
 
-    private func compileWithOutputMap(nodes: [ASTNode], outputMap: inout [String: OutputRef]) throws -> [String: Any] {
+    private func compileWithOutputMap(nodes: [ASTNode], outputMap: inout [String: OutputRef], declaredVariables: inout Set<String>) throws -> [String: Any] {
         var actions: [[String: Any]] = []
         var shortcutName = "Perspective Shortcut"
         var iconColor = 463140863 // blue default
@@ -57,7 +58,8 @@ struct Compiler: Sendable {
                     identifier: "is.workflow.actions.comment",
                     parameters: ["WFCommentActionText": text]
                 ))
-            case .variableDeclaration(let name, let value, _, _):
+            case .variableDeclaration(let name, let value, _, let location):
+                try validateExpression(value, declaredVariables: declaredVariables, location: location)
                 // When the value is a bare variable reference, set directly without an intermediary action
                 if case .variableReference(let refName) = value {
                     let wfInput: [String: Any]
@@ -105,6 +107,7 @@ struct Compiler: Sendable {
                         ]
                     ))
                 }
+                declaredVariables.insert(name)
             case .actionCall(let name, let arguments, let output, let location):
                 let def = registry.actions[name]
                 // If action contains dots, treat as raw identifier (3rd party app action)
@@ -134,6 +137,7 @@ struct Compiler: Sendable {
                 }
 
                 for (label, value) in arguments {
+                    try validateExpression(value, declaredVariables: declaredVariables, location: location)
                     if let label {
                         let resolvedValue: Any
 
@@ -214,9 +218,11 @@ struct Compiler: Sendable {
                 // Track output for ActionOutput references
                 if let output {
                     outputMap[output] = OutputRef(uuid: uuid, name: output)
+                    declaredVariables.insert(output)
                 }
 
-            case .ifStatement(let condition, let thenBody, let elseBody, _):
+            case .ifStatement(let condition, let thenBody, let elseBody, let location):
+                try validateCondition(condition, declaredVariables: declaredVariables, location: location)
                 let groupID = UUID().uuidString
                 // Emit conditional start
                 var condParams: [String: Any] = ["GroupingIdentifier": groupID, "WFControlFlowMode": 0]
@@ -225,7 +231,7 @@ struct Compiler: Sendable {
 
                 // Emit then body
                 for bodyNode in thenBody {
-                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap)
+                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
                     if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                         actions.append(contentsOf: bodyActions)
                     }
@@ -238,7 +244,7 @@ struct Compiler: Sendable {
                         parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 1]
                     ))
                     for bodyNode in elseBody {
-                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap)
+                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
                         if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                             actions.append(contentsOf: bodyActions)
                         }
@@ -259,7 +265,7 @@ struct Compiler: Sendable {
                     parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 0, "WFRepeatCount": countValue]
                 ))
                 for bodyNode in body {
-                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap)
+                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
                     if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                         actions.append(contentsOf: bodyActions)
                     }
@@ -277,7 +283,7 @@ struct Compiler: Sendable {
                     parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 0, "WFInput": collectionValue]
                 ))
                 for bodyNode in body {
-                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap)
+                    let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
                     if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                         actions.append(contentsOf: bodyActions)
                     }
@@ -309,7 +315,7 @@ struct Compiler: Sendable {
                         ]
                     ))
                     for bodyNode in menuCase.body {
-                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap)
+                        let compiled = try compileWithOutputMap(nodes: [bodyNode], outputMap: &outputMap, declaredVariables: &declaredVariables)
                         if let bodyActions = compiled["WFWorkflowActions"] as? [[String: Any]] {
                             actions.append(contentsOf: bodyActions)
                         }
@@ -574,6 +580,42 @@ struct Compiler: Sendable {
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 3 // less than
             params["WFConditionalActionString"] = try expressionToPlainValue(right)
+        }
+    }
+
+    // MARK: - Variable validation
+
+    private func validateExpression(_ expr: Expression, declaredVariables: Set<String>, location: SourceLocation) throws {
+        switch expr {
+        case .variableReference(let name):
+            if !declaredVariables.contains(name) {
+                throw CompilerError(message: "undefined variable '\(name)'", location: location)
+            }
+        case .interpolatedString(let parts):
+            for case .variable(let name) in parts {
+                if !declaredVariables.contains(name) {
+                    throw CompilerError(message: "undefined variable '\(name)'", location: location)
+                }
+            }
+        case .dictionaryLiteral(let entries):
+            for entry in entries {
+                try validateExpression(entry.key, declaredVariables: declaredVariables, location: location)
+                try validateExpression(entry.value, declaredVariables: declaredVariables, location: location)
+            }
+        default:
+            break
+        }
+    }
+
+    private func validateCondition(_ condition: Condition, declaredVariables: Set<String>, location: SourceLocation) throws {
+        switch condition {
+        case .equals(let left, let right),
+             .notEquals(let left, let right),
+             .contains(let left, let right),
+             .greaterThan(let left, let right),
+             .lessThan(let left, let right):
+            try validateExpression(left, declaredVariables: declaredVariables, location: location)
+            try validateExpression(right, declaredVariables: declaredVariables, location: location)
         }
     }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -402,6 +402,10 @@ struct Compiler: Sendable {
                 throw CompilerError(message: "#include directives must be resolved by the preprocessor before compilation", location: location)
             case .fragmentMarker(let location):
                 throw CompilerError(message: "#fragment markers must be resolved by the preprocessor before compilation", location: location)
+            case .providesDeclaration(_, let location):
+                throw CompilerError(message: "#provides declarations must be resolved by the preprocessor before compilation", location: location)
+            case .requiresDeclaration(_, let location):
+                throw CompilerError(message: "#requires declarations must be resolved by the preprocessor before compilation", location: location)
             }
         }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -803,7 +803,8 @@ struct Compiler: Sendable {
             "leaf": 59816, "paintbrush": 59817, "pencil": 59818,
             "scissors": 59819, "wand": 59820, "cube": 59821,
             "download": 59822, "upload": 59823, "share": 59824,
-            "trash": 59825, "magnifyingglass": 59826
+            "trash": 59825, "magnifyingglass": 59826,
+            "robot": 61566
         ]
         return glyphs[name.lowercased()] ?? 59771
     }

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -128,7 +128,7 @@ struct Compiler: Sendable {
                     if case .dictionaryLiteral = value {
                         sourceAction = try buildDictionaryAction(from: value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                     } else {
-                        sourceAction = try buildTextAction(from: value)
+                        sourceAction = try buildTextAction(from: value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                     }
                     actions.append(sourceAction)
                     actions.append(buildAction(
@@ -178,7 +178,7 @@ struct Compiler: Sendable {
                             let tkParam = toolKitParams?[label]
                             if tkParam?.isDynamicEntity == true || tkParam?.typeKind == 2 {
                                 // Dynamic entity: wrap as { value, title, subtitle }
-                                let plainVal = try expressionToPlainValue(value)
+                                let plainVal = try expressionToPlainValue(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                                 let strVal = "\(plainVal)"
                                 resolvedValue = [
                                     "value": strVal,
@@ -187,10 +187,10 @@ struct Compiler: Sendable {
                                 ] as [String: Any]
                             } else if tkParam?.typeKind == 3 || tkParam?.typeKind == 4 {
                                 // Static enum: use plain value
-                                resolvedValue = try expressionToPlainValue(value)
+                                resolvedValue = try expressionToPlainValue(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                             } else {
                                 // Primitives (string, int, bool, etc.): use plain values
-                                resolvedValue = try expressionToPlainValue(value)
+                                resolvedValue = try expressionToPlainValue(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                             }
                         } else {
                             // Built-in action — use ActionRegistry parameter definitions
@@ -209,7 +209,7 @@ struct Compiler: Sendable {
                                let intVal = valueMap[s] {
                                 resolvedValue = intVal
                             } else if let paramType = paramDef?.type, (paramType == "enum" || paramType == "boolean" || paramType == "plainString") {
-                                resolvedValue = try expressionToPlainValue(value)
+                                resolvedValue = try expressionToPlainValue(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
                             } else if let paramType = paramDef?.type, paramType == "variable",
                                       case .variableReference(let varName) = value {
                                 // Variable-typed parameters need WFTextTokenAttachment,
@@ -306,7 +306,7 @@ struct Compiler: Sendable {
 
             case .repeatLoop(let count, let body, _):
                 let groupID = UUID().uuidString
-                let countValue = try expressionToValue(count)
+                let countValue = try expressionToValueWithOutputMap(count, outputMap: outputMap, forEachVarNames: forEachVarNames)
                 actions.append(buildAction(
                     identifier: "is.workflow.actions.repeat.count",
                     parameters: ["GroupingIdentifier": groupID, "WFControlFlowMode": 0, "WFRepeatCount": countValue]
@@ -534,8 +534,8 @@ struct Compiler: Sendable {
         ] as [String: Any]
     }
 
-    private func buildTextAction(from expression: Expression) throws -> [String: Any] {
-        let value = try expressionToValue(expression)
+    private func buildTextAction(from expression: Expression, outputMap: [String: OutputRef] = [:], forEachVarNames: Set<String> = []) throws -> [String: Any] {
+        let value = try expressionToValueWithOutputMap(expression, outputMap: outputMap, forEachVarNames: forEachVarNames)
         let uuid = UUID().uuidString
         return buildAction(
             identifier: "is.workflow.actions.gettext",
@@ -556,18 +556,14 @@ struct Compiler: Sendable {
         ]
     }
 
-    private func expressionToPlainValue(_ expr: Expression) throws -> Any {
+    private func expressionToPlainValue(_ expr: Expression, outputMap: [String: OutputRef] = [:], forEachVarNames: Set<String> = []) throws -> Any {
         switch expr {
         case .stringLiteral(let s): return s
         case .numberLiteral(let n): return n == n.rounded() ? Int(n) : n
         case .boolLiteral(let b): return b
-        case .dictionaryLiteral: return try expressionToValue(expr)
-        default: return try expressionToValue(expr)
+        case .dictionaryLiteral: return try expressionToValueWithOutputMap(expr, outputMap: outputMap, forEachVarNames: forEachVarNames)
+        default: return try expressionToValueWithOutputMap(expr, outputMap: outputMap, forEachVarNames: forEachVarNames)
         }
-    }
-
-    private func expressionToValue(_ expr: Expression) throws -> Any {
-        return try expressionToValueWithOutputMap(expr, outputMap: [:])
     }
 
     private func expressionToValueWithOutputMap(_ expr: Expression, outputMap: [String: OutputRef], forEachVarNames: Set<String> = []) throws -> Any {
@@ -727,23 +723,23 @@ struct Compiler: Sendable {
         case .equals(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 4 // equals
-            params["WFConditionalActionString"] = try expressionToPlainValue(right)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right, outputMap: outputMap, forEachVarNames: forEachVarNames)
         case .notEquals(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 5 // not equals
-            params["WFConditionalActionString"] = try expressionToPlainValue(right)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right, outputMap: outputMap, forEachVarNames: forEachVarNames)
         case .contains(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 99 // contains
-            params["WFConditionalActionString"] = try expressionToPlainValue(right)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right, outputMap: outputMap, forEachVarNames: forEachVarNames)
         case .greaterThan(let left, let right):
             params["WFInput"] = try resolveInput(left, coercionClass: "WFNumberContentItem")
             params["WFCondition"] = 2 // greater than
-            params["WFNumberValue"] = "\(try expressionToPlainValue(right))"
+            params["WFNumberValue"] = "\(try expressionToPlainValue(right, outputMap: outputMap, forEachVarNames: forEachVarNames))"
         case .lessThan(let left, let right):
             params["WFInput"] = try resolveInput(left, coercionClass: "WFNumberContentItem")
             params["WFCondition"] = 3 // less than
-            params["WFNumberValue"] = "\(try expressionToPlainValue(right))"
+            params["WFNumberValue"] = "\(try expressionToPlainValue(right, outputMap: outputMap, forEachVarNames: forEachVarNames))"
         }
     }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -481,22 +481,35 @@ struct Compiler: Sendable {
     private func applyCondition(_ condition: Condition, to params: inout [String: Any], outputMap: [String: OutputRef]) throws {
         // Helper: resolve the left-hand side of a condition.
         // Conditionals use a nested format for WFInput:
-        //   { Type: "Variable", Variable: { Value: { ... }, WFSerializationType: "WFTextTokenAttachment" } }
+        //   { Type: "Variable", Variable: { Value: { ..., Aggrandizements: [coerce to string] }, WFSerializationType: "WFTextTokenAttachment" } }
+        // The Aggrandizements coercion to WFStringContentItem is required
+        // so Shortcuts treats the value as a string before comparing.
         func resolveInput(_ expr: Expression) throws -> Any {
             if case .variableReference(let name) = expr {
+                let coercion: [[String: Any]] = [
+                    [
+                        "CoercionItemClass": "WFStringContentItem",
+                        "Type": "WFCoercionVariableAggrandizement"
+                    ]
+                ]
                 let inner: [String: Any]
                 if let ref = outputMap[name] {
                     inner = [
                         "Value": [
+                            "Aggrandizements": coercion,
                             "OutputUUID": ref.uuid,
                             "Type": "ActionOutput",
                             "OutputName": ref.name
-                        ],
+                        ] as [String: Any],
                         "WFSerializationType": "WFTextTokenAttachment"
                     ] as [String: Any]
                 } else {
                     inner = [
-                        "Value": ["VariableName": name, "Type": "Variable"],
+                        "Value": [
+                            "Aggrandizements": coercion,
+                            "VariableName": name,
+                            "Type": "Variable"
+                        ] as [String: Any],
                         "WFSerializationType": "WFTextTokenAttachment"
                     ] as [String: Any]
                 }
@@ -512,23 +525,23 @@ struct Compiler: Sendable {
         case .equals(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 4 // equals
-            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right)
         case .notEquals(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 5 // not equals
-            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right)
         case .contains(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 99 // contains
-            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right)
         case .greaterThan(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 2 // greater than
-            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right)
         case .lessThan(let left, let right):
             params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 3 // less than
-            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
+            params["WFConditionalActionString"] = try expressionToPlainValue(right)
         }
     }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -188,7 +188,7 @@ struct Compiler: Sendable {
                 let groupID = UUID().uuidString
                 // Emit conditional start
                 var condParams: [String: Any] = ["GroupingIdentifier": groupID, "WFControlFlowMode": 0]
-                try applyCondition(condition, to: &condParams)
+                try applyCondition(condition, to: &condParams, outputMap: outputMap)
                 actions.append(buildAction(identifier: "is.workflow.actions.conditional", parameters: condParams))
 
                 // Emit then body
@@ -478,28 +478,57 @@ struct Compiler: Sendable {
         }
     }
 
-    private func applyCondition(_ condition: Condition, to params: inout [String: Any]) throws {
+    private func applyCondition(_ condition: Condition, to params: inout [String: Any], outputMap: [String: OutputRef]) throws {
+        // Helper: resolve the left-hand side of a condition.
+        // Conditionals use a nested format for WFInput:
+        //   { Type: "Variable", Variable: { Value: { ... }, WFSerializationType: "WFTextTokenAttachment" } }
+        func resolveInput(_ expr: Expression) throws -> Any {
+            if case .variableReference(let name) = expr {
+                let inner: [String: Any]
+                if let ref = outputMap[name] {
+                    inner = [
+                        "Value": [
+                            "OutputUUID": ref.uuid,
+                            "Type": "ActionOutput",
+                            "OutputName": ref.name
+                        ],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ] as [String: Any]
+                } else {
+                    inner = [
+                        "Value": ["VariableName": name, "Type": "Variable"],
+                        "WFSerializationType": "WFTextTokenAttachment"
+                    ] as [String: Any]
+                }
+                return [
+                    "Type": "Variable",
+                    "Variable": inner
+                ] as [String: Any]
+            }
+            return try expressionToValueWithOutputMap(expr, outputMap: outputMap)
+        }
+
         switch condition {
         case .equals(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 4 // equals
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .notEquals(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 5 // not equals
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .contains(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 99 // contains
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .greaterThan(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 2 // greater than
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         case .lessThan(let left, let right):
-            params["WFInput"] = try expressionToValue(left)
+            params["WFInput"] = try resolveInput(left)
             params["WFCondition"] = 3 // less than
-            params["WFConditionalActionString"] = try expressionToValue(right)
+            params["WFConditionalActionString"] = try expressionToValueWithOutputMap(right, outputMap: outputMap)
         }
     }
 

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -222,6 +222,25 @@ struct Compiler: Sendable {
                                 resolvedValue = intVal
                             } else if let paramType = paramDef?.type, (paramType == "enum" || paramType == "boolean" || paramType == "plainString") {
                                 resolvedValue = try expressionToPlainValue(value, outputMap: outputMap, forEachVarNames: forEachVarNames)
+                            } else if let paramType = paramDef?.type, paramType == "textSeparator",
+                                      case .stringLiteral(let s) = value {
+                                // Shortcuts' splitText/combineText take WFTextSeparator
+                                // as an enum ("New Lines", "Spaces", "Every Character",
+                                // "Custom"). When the enum is "Custom", a sibling
+                                // WFTextCustomSeparator carries the actual character.
+                                // Accept any string from the user and auto-route:
+                                // known enum values pass through; anything else becomes
+                                // a Custom separator. Without this, `separator: ","`
+                                // silently set WFTextSeparator="," and Shortcuts fell
+                                // back to the default (New Lines), producing a single-
+                                // element list instead of three.
+                                let knownEnums: Set<String> = ["New Lines", "Spaces", "Every Character", "Custom"]
+                                if knownEnums.contains(s) {
+                                    resolvedValue = s
+                                } else {
+                                    resolvedValue = "Custom"
+                                    params["WFTextCustomSeparator"] = s
+                                }
                             } else if let paramType = paramDef?.type, paramType == "variable",
                                       case .variableReference(let varName) = value {
                                 // Variable-typed parameters need WFTextTokenAttachment,

--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -47,6 +47,18 @@ struct Compiler: Sendable {
         forEachVars.contains(name) ? "Repeat Item" : name
     }
 
+    /// Maps a friendly `coerce` value from actions.json to the Shortcuts
+    /// `CoercionItemClass` string used inside a WFCoercionVariableAggrandizement.
+    /// Unknown values are ignored (treated as no coercion).
+    private func coerceItemClass(for coerce: String) -> String? {
+        switch coerce {
+        case "string", "text": return "WFStringContentItem"
+        case "number": return "WFNumberContentItem"
+        case "dictionary": return "WFDictionaryContentItem"
+        default: return nil
+        }
+    }
+
     func compile(nodes: [ASTNode]) throws -> [String: Any] {
         var outputMap: [String: OutputRef] = [:]
         var declaredVariables: Set<String> = [Self.shortcutInputName]
@@ -215,26 +227,40 @@ struct Compiler: Sendable {
                                 // Variable-typed parameters need WFTextTokenAttachment,
                                 // not WFTextTokenString, so the action receives the
                                 // output directly rather than as interpolated text.
-                                if let ref = outputMap[varName] {
-                                    resolvedValue = [
-                                        "Value": [
-                                            "OutputUUID": ref.uuid,
-                                            "Type": "ActionOutput",
-                                            "OutputName": ref.name
-                                        ],
-                                        "WFSerializationType": "WFTextTokenAttachment"
-                                    ] as [String: Any]
-                                } else if Self.isShortcutInput(varName) {
-                                    resolvedValue = [
-                                        "Value": Self.extensionInputAttachment(),
-                                        "WFSerializationType": "WFTextTokenAttachment"
-                                    ] as [String: Any]
-                                } else {
-                                    resolvedValue = [
-                                        "Value": ["VariableName": Self.resolveVariableName(varName, forEachVars: forEachVarNames), "Type": "Variable"],
-                                        "WFSerializationType": "WFTextTokenAttachment"
-                                    ] as [String: Any]
+                                //
+                                // Optional `coerce` on the parameter injects a
+                                // WFCoercionVariableAggrandizement so Shortcuts reads
+                                // the upstream value in the requested form — e.g.
+                                // "string" forces a File (such as downloadURL's
+                                // response) to be read as its text content rather
+                                // than as the File object itself, which is what
+                                // makes `getDictionary` actually see the JSON body.
+                                let coerceClass: String? = paramDef?.coerce.flatMap { coerceItemClass(for: $0) }
+                                let aggrandizements: [[String: Any]]? = coerceClass.map { cls in
+                                    [[
+                                        "CoercionItemClass": cls,
+                                        "Type": "WFCoercionVariableAggrandizement"
+                                    ]]
                                 }
+                                var inner: [String: Any]
+                                if let ref = outputMap[varName] {
+                                    inner = [
+                                        "OutputUUID": ref.uuid,
+                                        "Type": "ActionOutput",
+                                        "OutputName": ref.name
+                                    ]
+                                } else if Self.isShortcutInput(varName) {
+                                    inner = Self.extensionInputAttachment()
+                                } else {
+                                    inner = ["VariableName": Self.resolveVariableName(varName, forEachVars: forEachVarNames), "Type": "Variable"]
+                                }
+                                if let aggrandizements {
+                                    inner["Aggrandizements"] = aggrandizements
+                                }
+                                resolvedValue = [
+                                    "Value": inner,
+                                    "WFSerializationType": "WFTextTokenAttachment"
+                                ] as [String: Any]
                             } else if let paramType = paramDef?.type, paramType == "iCloudFolder" {
                                 // iCloudFolder: emit an implicit Text action with the
                                 // folder name string, then reference its output as a

--- a/Sources/perspective-cuts/Compiler/LockAnalyzer.swift
+++ b/Sources/perspective-cuts/Compiler/LockAnalyzer.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Provides authentication policy lookups for actions.
+/// Production code uses ToolKitReader; tests can supply a stub.
+protocol AuthenticationPolicyProvider {
+    func getAuthenticationPolicy(identifier: String) -> String?
+}
+
+extension ToolKitReader: AuthenticationPolicyProvider {}
+
+/// Analyzes a shortcut's AST to determine which actions require the device to be unlocked.
+///
+/// Authentication policy data comes from Apple's ToolKit database (the authoritative source).
+/// If this approach proves problematic (e.g., ToolKit DB not available on all machines),
+/// the fallback plan is to copy authenticationPolicy values into actions.json as traits.
+/// See: https://github.com/akostibas/perspective-cuts/issues/3
+struct LockAnalyzer {
+
+    /// A single finding: an action that requires device unlock.
+    struct Diagnostic: CustomStringConvertible {
+        let actionName: String
+        let identifier: String
+        let policy: String
+        let location: SourceLocation
+        /// Describes the branch context, e.g. "when x == \"foo\"", or nil if always reachable.
+        let branchContext: String?
+
+        var description: String {
+            let reachability = branchContext.map { "reachable \($0)" } ?? "always reachable"
+            return "\(location): \(actionName) (\(policy)) — \(reachability)"
+        }
+    }
+
+    let registry: ActionRegistry
+    let policyProvider: AuthenticationPolicyProvider
+
+    func analyze(nodes: [ASTNode]) -> [Diagnostic] {
+        var diagnostics: [Diagnostic] = []
+        walk(nodes: nodes, branchContext: nil, diagnostics: &diagnostics)
+        return diagnostics
+    }
+
+    // MARK: - Private
+
+    private func walk(nodes: [ASTNode], branchContext: String?, diagnostics: inout [Diagnostic]) {
+        for node in nodes {
+            switch node {
+            case .actionCall(let name, _, _, let location):
+                if let diag = checkAction(name: name, location: location, branchContext: branchContext) {
+                    diagnostics.append(diag)
+                }
+
+            case .ifStatement(let condition, let thenBody, let elseBody, _):
+                let condStr = describeCondition(condition)
+                walk(nodes: thenBody, branchContext: composeContext(branchContext, "when \(condStr)"), diagnostics: &diagnostics)
+                if let elseBody {
+                    walk(nodes: elseBody, branchContext: composeContext(branchContext, "when not (\(condStr))"), diagnostics: &diagnostics)
+                }
+
+            case .menu(let title, let cases, _):
+                for menuCase in cases {
+                    let caseContext = "in menu \"\(title)\" case \"\(menuCase.label)\""
+                    walk(nodes: menuCase.body, branchContext: composeContext(branchContext, caseContext), diagnostics: &diagnostics)
+                }
+
+            case .repeatLoop(_, let body, _):
+                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
+
+            case .forEachLoop(_, _, let body, _):
+                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
+
+            case .functionDeclaration(_, let body, _):
+                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
+
+            default:
+                break
+            }
+        }
+    }
+
+    private func checkAction(name: String, location: SourceLocation, branchContext: String?) -> Diagnostic? {
+        // Resolve the ToolKit identifier: dotted names are already identifiers,
+        // short names go through the registry.
+        let identifier: String
+        if name.contains(".") {
+            identifier = name
+        } else if let def = registry.actions[name] {
+            identifier = def.identifier
+        } else {
+            return nil // Unknown action — can't check
+        }
+
+        guard let policy = policyProvider.getAuthenticationPolicy(identifier: identifier) else {
+            return nil // Not in ToolKit DB — can't verify
+        }
+
+        guard policy != "none" else {
+            return nil // No unlock required
+        }
+
+        return Diagnostic(
+            actionName: name,
+            identifier: identifier,
+            policy: policy,
+            location: location,
+            branchContext: branchContext
+        )
+    }
+
+    private func composeContext(_ existing: String?, _ new: String) -> String {
+        if let existing {
+            return "\(existing), \(new)"
+        }
+        return new
+    }
+
+    private func describeCondition(_ condition: Condition) -> String {
+        switch condition {
+        case .equals(let left, let right):
+            return "\(describeExpr(left)) == \(describeExpr(right))"
+        case .notEquals(let left, let right):
+            return "\(describeExpr(left)) != \(describeExpr(right))"
+        case .contains(let left, let right):
+            return "\(describeExpr(left)) contains \(describeExpr(right))"
+        case .greaterThan(let left, let right):
+            return "\(describeExpr(left)) > \(describeExpr(right))"
+        case .lessThan(let left, let right):
+            return "\(describeExpr(left)) < \(describeExpr(right))"
+        }
+    }
+
+    private func describeExpr(_ expr: Expression) -> String {
+        switch expr {
+        case .stringLiteral(let s): return "\"\(s)\""
+        case .numberLiteral(let n): return n.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(n)) : String(n)
+        case .boolLiteral(let b): return String(b)
+        case .variableReference(let v): return v
+        case .interpolatedString: return "<interpolated string>"
+        case .dictionaryLiteral: return "<dictionary>"
+        }
+    }
+}

--- a/Sources/perspective-cuts/Compiler/LockAnalyzer.swift
+++ b/Sources/perspective-cuts/Compiler/LockAnalyzer.swift
@@ -16,13 +16,11 @@ extension ToolKitReader: AuthenticationPolicyProvider {}
 /// See: https://github.com/akostibas/perspective-cuts/issues/3
 struct LockAnalyzer {
 
-    /// A single finding: an action that requires device unlock.
     struct Diagnostic: CustomStringConvertible {
         let actionName: String
         let identifier: String
         let policy: String
         let location: SourceLocation
-        /// Describes the branch context, e.g. "when x == \"foo\"", or nil if always reachable.
         let branchContext: String?
 
         var description: String {
@@ -36,107 +34,38 @@ struct LockAnalyzer {
 
     func analyze(nodes: [ASTNode]) -> [Diagnostic] {
         var diagnostics: [Diagnostic] = []
-        walk(nodes: nodes, branchContext: nil, diagnostics: &diagnostics)
+        ASTWalker.walk(nodes: nodes) { visit in
+            if let diag = checkAction(visit) {
+                diagnostics.append(diag)
+            }
+        }
         return diagnostics
     }
 
-    // MARK: - Private
-
-    private func walk(nodes: [ASTNode], branchContext: String?, diagnostics: inout [Diagnostic]) {
-        for node in nodes {
-            switch node {
-            case .actionCall(let name, _, _, let location):
-                if let diag = checkAction(name: name, location: location, branchContext: branchContext) {
-                    diagnostics.append(diag)
-                }
-
-            case .ifStatement(let condition, let thenBody, let elseBody, _):
-                let condStr = describeCondition(condition)
-                walk(nodes: thenBody, branchContext: composeContext(branchContext, "when \(condStr)"), diagnostics: &diagnostics)
-                if let elseBody {
-                    walk(nodes: elseBody, branchContext: composeContext(branchContext, "when not (\(condStr))"), diagnostics: &diagnostics)
-                }
-
-            case .menu(let title, let cases, _):
-                for menuCase in cases {
-                    let caseContext = "in menu \"\(title)\" case \"\(menuCase.label)\""
-                    walk(nodes: menuCase.body, branchContext: composeContext(branchContext, caseContext), diagnostics: &diagnostics)
-                }
-
-            case .repeatLoop(_, let body, _):
-                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
-
-            case .forEachLoop(_, _, let body, _):
-                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
-
-            case .functionDeclaration(_, let body, _):
-                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
-
-            default:
-                break
-            }
-        }
-    }
-
-    private func checkAction(name: String, location: SourceLocation, branchContext: String?) -> Diagnostic? {
-        // Resolve the ToolKit identifier: dotted names are already identifiers,
-        // short names go through the registry.
+    private func checkAction(_ visit: ASTWalker.ActionVisit) -> Diagnostic? {
         let identifier: String
-        if name.contains(".") {
-            identifier = name
-        } else if let def = registry.actions[name] {
+        if visit.name.contains(".") {
+            identifier = visit.name
+        } else if let def = registry.actions[visit.name] {
             identifier = def.identifier
         } else {
-            return nil // Unknown action — can't check
+            return nil
         }
 
         guard let policy = policyProvider.getAuthenticationPolicy(identifier: identifier) else {
-            return nil // Not in ToolKit DB — can't verify
+            return nil
         }
 
         guard policy != "none" else {
-            return nil // No unlock required
+            return nil
         }
 
         return Diagnostic(
-            actionName: name,
+            actionName: visit.name,
             identifier: identifier,
             policy: policy,
-            location: location,
-            branchContext: branchContext
+            location: visit.location,
+            branchContext: visit.branchContext
         )
-    }
-
-    private func composeContext(_ existing: String?, _ new: String) -> String {
-        if let existing {
-            return "\(existing), \(new)"
-        }
-        return new
-    }
-
-    private func describeCondition(_ condition: Condition) -> String {
-        switch condition {
-        case .equals(let left, let right):
-            return "\(describeExpr(left)) == \(describeExpr(right))"
-        case .notEquals(let left, let right):
-            return "\(describeExpr(left)) != \(describeExpr(right))"
-        case .contains(let left, let right):
-            return "\(describeExpr(left)) contains \(describeExpr(right))"
-        case .greaterThan(let left, let right):
-            return "\(describeExpr(left)) > \(describeExpr(right))"
-        case .lessThan(let left, let right):
-            return "\(describeExpr(left)) < \(describeExpr(right))"
-        }
-    }
-
-    private func describeExpr(_ expr: Expression) -> String {
-        switch expr {
-        case .stringLiteral(let s): return "\"\(s)\""
-        case .numberLiteral(let n): return n.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(n)) : String(n)
-        case .boolLiteral(let b): return String(b)
-        case .variableReference(let v): return v
-        case .interpolatedString: return "<interpolated string>"
-        case .dictionaryLiteral: return "<dictionary>"
-        }
     }
 }

--- a/Sources/perspective-cuts/Compiler/Preprocessor.swift
+++ b/Sources/perspective-cuts/Compiler/Preprocessor.swift
@@ -18,12 +18,14 @@ struct Preprocessor: Sendable {
     let sourceDirectory: URL
 
     /// Resolves all `#include` directives in the given AST by reading,
-    /// parsing, and inlining the referenced files. Strips `importStatement`
-    /// and `metadata` nodes from included content.
+    /// parsing, and inlining the referenced files. Validates `#requires`
+    /// dependencies and auto-prefixes internal fragment variables.
     ///
     /// Errors if:
     /// - A `#fragment` file is being compiled as the top-level source
     /// - An included file cannot be found or parsed
+    /// - A `#requires` variable is not in scope at the include site
+    /// - Two fragments both `#provides` the same variable
     func preprocess(nodes: [ASTNode], isTopLevel: Bool = true) throws -> [ASTNode] {
         // Top-level fragment check
         if isTopLevel && nodes.contains(where: { if case .fragmentMarker = $0 { return true } else { return false } }) {
@@ -34,15 +36,33 @@ struct Preprocessor: Sendable {
             )
         }
 
+        // Track all variables in scope at each point during processing.
+        // This includes variables from the main file (var declarations, -> captures)
+        // and #provides from earlier fragments.
+        var scopedVariables: Set<String> = []
+        // Track all provided variable names globally to detect duplicates.
+        var allProvided: [String: String] = [:] // varName -> fragment path that provided it
+
         var result: [ASTNode] = []
         for node in nodes {
             switch node {
             case .includeDirective(let path, let location):
-                let included = try resolveInclude(path: path, location: location)
+                let included = try resolveInclude(
+                    path: path,
+                    location: location,
+                    scopedVariables: &scopedVariables,
+                    allProvided: &allProvided
+                )
                 result.append(contentsOf: included)
-            case .fragmentMarker:
-                // Strip #fragment markers — they're metadata for the preprocessor only
+            case .fragmentMarker, .providesDeclaration, .requiresDeclaration:
+                // Strip preprocessor-only directives from top-level file
                 break
+            case .variableDeclaration(let name, _, _, _):
+                scopedVariables.insert(name)
+                result.append(node)
+            case .actionCall(_, _, let output, _):
+                if let output { scopedVariables.insert(output) }
+                result.append(node)
             default:
                 result.append(node)
             }
@@ -50,7 +70,12 @@ struct Preprocessor: Sendable {
         return result
     }
 
-    private func resolveInclude(path: String, location: SourceLocation) throws -> [ASTNode] {
+    private func resolveInclude(
+        path: String,
+        location: SourceLocation,
+        scopedVariables: inout Set<String>,
+        allProvided: inout [String: String]
+    ) throws -> [ASTNode] {
         let fileURL = sourceDirectory.appendingPathComponent(path)
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             throw PreprocessorError(
@@ -63,16 +88,236 @@ struct Preprocessor: Sendable {
         let tokens = try Lexer(source: source).tokenize()
         let fragmentNodes = try Parser(tokens: tokens).parse()
 
-        // Strip import statements, metadata, and fragment markers from included content
-        let filtered = fragmentNodes.filter { node in
-            switch node {
-            case .importStatement: return false
-            case .metadata: return false
-            case .fragmentMarker: return false
-            default: return true
+        // Extract #provides and #requires from the fragment
+        var provides: Set<String> = []
+        var requires: Set<String> = []
+        for node in fragmentNodes {
+            if case .providesDeclaration(let vars, _) = node {
+                for v in vars { provides.insert(v) }
+            }
+            if case .requiresDeclaration(let vars, _) = node {
+                for v in vars { requires.insert(v) }
             }
         }
 
-        return filtered
+        // Validate #requires are satisfied by variables in scope
+        for req in requires {
+            if !scopedVariables.contains(req) {
+                throw PreprocessorError(
+                    message: "Fragment '\(path)' requires variable '\(req)' which is not in scope at the include site. Available: \(scopedVariables.sorted().joined(separator: ", "))",
+                    location: location
+                )
+            }
+        }
+
+        // Check for duplicate #provides
+        for prov in provides {
+            if let existingSource = allProvided[prov] {
+                throw PreprocessorError(
+                    message: "Variable '\(prov)' is provided by both '\(existingSource)' and '\(path)'",
+                    location: location
+                )
+            }
+            allProvided[prov] = path
+        }
+
+        // Strip import, metadata, fragment markers, provides, requires
+        let actionNodes = fragmentNodes.filter { node in
+            switch node {
+            case .importStatement, .metadata, .fragmentMarker,
+                 .providesDeclaration, .requiresDeclaration:
+                return false
+            default:
+                return true
+            }
+        }
+
+        // Auto-prefix internal variables if fragment has #provides declarations.
+        // Variables NOT in #provides and NOT in #requires are internal.
+        let hasContracts = !provides.isEmpty || !requires.isEmpty
+        let prefixedNodes: [ASTNode]
+        if hasContracts {
+            let prefix = fragmentPrefix(from: path)
+            let exempt = provides.union(requires)
+            prefixedNodes = prefixNodes(actionNodes, prefix: prefix, exempt: exempt)
+        } else {
+            prefixedNodes = actionNodes
+        }
+
+        // Register provided variables in scope for subsequent fragments
+        for prov in provides {
+            scopedVariables.insert(prov)
+        }
+        // Also register any unprefixed variables declared in fragments without contracts
+        if !hasContracts {
+            for node in prefixedNodes {
+                switch node {
+                case .variableDeclaration(let name, _, _, _):
+                    scopedVariables.insert(name)
+                case .actionCall(_, _, let output, _):
+                    if let output { scopedVariables.insert(output) }
+                default: break
+                }
+            }
+        }
+
+        return prefixedNodes
+    }
+
+    // MARK: - Fragment Name Prefix
+
+    /// Derives a camelCase prefix from a file path.
+    /// e.g. "fragments/config-loader.perspective" → "configLoader__"
+    static func fragmentPrefix(from path: String) -> String {
+        let filename = URL(fileURLWithPath: path).deletingPathExtension().lastPathComponent
+        let parts = filename.split(whereSeparator: { $0 == "-" || $0 == "_" })
+        let camelCased = parts.enumerated().map { i, part in
+            i == 0 ? part.lowercased() : part.prefix(1).uppercased() + part.dropFirst().lowercased()
+        }.joined()
+        return camelCased + "__"
+    }
+
+    private func fragmentPrefix(from path: String) -> String {
+        Self.fragmentPrefix(from: path)
+    }
+
+    // MARK: - Variable Auto-Prefixing
+
+    /// Walks the AST and renames all variables that are NOT in the exempt set.
+    /// Loop iterator variables (for-each item names) are collected during traversal
+    /// and also exempted since they map to Shortcuts "Repeat Item" at runtime.
+    private func prefixNodes(_ nodes: [ASTNode], prefix: String, exempt: Set<String>) -> [ASTNode] {
+        // First pass: collect all for-each loop variable names so they're exempt
+        var loopVars: Set<String> = []
+        collectLoopVars(nodes, into: &loopVars)
+        let allExempt = exempt.union(loopVars)
+
+        return nodes.map { prefixNode($0, prefix: prefix, exempt: allExempt) }
+    }
+
+    private func collectLoopVars(_ nodes: [ASTNode], into vars: inout Set<String>) {
+        for node in nodes {
+            switch node {
+            case .forEachLoop(let itemName, _, let body, _):
+                vars.insert(itemName)
+                collectLoopVars(body, into: &vars)
+            case .ifStatement(_, let thenBody, let elseBody, _):
+                collectLoopVars(thenBody, into: &vars)
+                if let elseBody { collectLoopVars(elseBody, into: &vars) }
+            case .repeatLoop(_, let body, _):
+                collectLoopVars(body, into: &vars)
+            case .menu(_, let cases, _):
+                for c in cases { collectLoopVars(c.body, into: &vars) }
+            case .functionDeclaration(_, let body, _):
+                collectLoopVars(body, into: &vars)
+            default: break
+            }
+        }
+    }
+
+    private func prefixNode(_ node: ASTNode, prefix: String, exempt: Set<String>) -> ASTNode {
+        func rename(_ name: String) -> String {
+            exempt.contains(name) ? name : prefix + name
+        }
+
+        switch node {
+        case .variableDeclaration(let name, let value, let isConstant, let loc):
+            return .variableDeclaration(
+                name: rename(name),
+                value: prefixExpression(value, prefix: prefix, exempt: exempt),
+                isConstant: isConstant,
+                location: loc
+            )
+        case .actionCall(let name, let arguments, let output, let loc):
+            let prefixedArgs = arguments.map { (label: $0.label, value: prefixExpression($0.value, prefix: prefix, exempt: exempt)) }
+            return .actionCall(
+                name: name, // action names are NOT renamed
+                arguments: prefixedArgs,
+                output: output.map { rename($0) },
+                location: loc
+            )
+        case .ifStatement(let condition, let thenBody, let elseBody, let loc):
+            return .ifStatement(
+                condition: prefixCondition(condition, prefix: prefix, exempt: exempt),
+                thenBody: thenBody.map { prefixNode($0, prefix: prefix, exempt: exempt) },
+                elseBody: elseBody?.map { prefixNode($0, prefix: prefix, exempt: exempt) },
+                location: loc
+            )
+        case .repeatLoop(let count, let body, let loc):
+            return .repeatLoop(
+                count: prefixExpression(count, prefix: prefix, exempt: exempt),
+                body: body.map { prefixNode($0, prefix: prefix, exempt: exempt) },
+                location: loc
+            )
+        case .forEachLoop(let itemName, let collection, let body, let loc):
+            // itemName is exempt (collected in loopVars), but still rename collection refs
+            return .forEachLoop(
+                itemName: itemName, // never prefixed — maps to "Repeat Item"
+                collection: prefixExpression(collection, prefix: prefix, exempt: exempt),
+                body: body.map { prefixNode($0, prefix: prefix, exempt: exempt) },
+                location: loc
+            )
+        case .menu(let title, let cases, let loc):
+            let prefixedCases = cases.map { c in
+                (label: c.label, body: c.body.map { prefixNode($0, prefix: prefix, exempt: exempt) })
+            }
+            return .menu(title: title, cases: prefixedCases, location: loc)
+        case .functionDeclaration(let name, let body, let loc):
+            return .functionDeclaration(
+                name: rename(name),
+                body: body.map { prefixNode($0, prefix: prefix, exempt: exempt) },
+                location: loc
+            )
+        case .returnStatement(let value, let loc):
+            return .returnStatement(
+                value: value.map { prefixExpression($0, prefix: prefix, exempt: exempt) },
+                location: loc
+            )
+        case .comment, .importStatement, .metadata, .includeDirective,
+             .fragmentMarker, .providesDeclaration, .requiresDeclaration:
+            return node
+        }
+    }
+
+    private func prefixExpression(_ expr: Expression, prefix: String, exempt: Set<String>) -> Expression {
+        func rename(_ name: String) -> String {
+            exempt.contains(name) ? name : prefix + name
+        }
+
+        switch expr {
+        case .variableReference(let name):
+            return .variableReference(rename(name))
+        case .interpolatedString(let parts):
+            let prefixed = parts.map { part -> StringPart in
+                if case .variable(let name) = part {
+                    return .variable(rename(name))
+                }
+                return part
+            }
+            return .interpolatedString(parts: prefixed)
+        case .dictionaryLiteral(let entries):
+            let prefixed = entries.map { entry in
+                DictionaryEntry(
+                    key: prefixExpression(entry.key, prefix: prefix, exempt: exempt),
+                    value: prefixExpression(entry.value, prefix: prefix, exempt: exempt)
+                )
+            }
+            return .dictionaryLiteral(prefixed)
+        case .stringLiteral, .numberLiteral, .boolLiteral:
+            return expr
+        }
+    }
+
+    private func prefixCondition(_ condition: Condition, prefix: String, exempt: Set<String>) -> Condition {
+        func px(_ expr: Expression) -> Expression {
+            prefixExpression(expr, prefix: prefix, exempt: exempt)
+        }
+        switch condition {
+        case .equals(let l, let r): return .equals(left: px(l), right: px(r))
+        case .notEquals(let l, let r): return .notEquals(left: px(l), right: px(r))
+        case .contains(let l, let r): return .contains(left: px(l), right: px(r))
+        case .greaterThan(let l, let r): return .greaterThan(left: px(l), right: px(r))
+        case .lessThan(let l, let r): return .lessThan(left: px(l), right: px(r))
+        }
     }
 }

--- a/Sources/perspective-cuts/Compiler/Preprocessor.swift
+++ b/Sources/perspective-cuts/Compiler/Preprocessor.swift
@@ -54,6 +54,9 @@ struct Preprocessor: Sendable {
         var scopedVariables: Set<String> = []
         // Track all provided variable names globally to detect duplicates.
         var allProvided: [String: String] = [:] // varName -> fragment path that provided it
+        // Track variables assigned since the last #include, used to validate
+        // `#requires fresh:` — those variables must be (re-)set before each include.
+        var recentlyAssigned: Set<String> = []
 
         var result: [ASTNode] = []
         for node in nodes {
@@ -64,6 +67,7 @@ struct Preprocessor: Sendable {
                     location: location,
                     scopedVariables: &scopedVariables,
                     allProvided: &allProvided,
+                    recentlyAssigned: &recentlyAssigned,
                     includeStack: includeStack
                 )
                 result.append(contentsOf: included)
@@ -72,9 +76,13 @@ struct Preprocessor: Sendable {
                 break
             case .variableDeclaration(let name, _, _, _):
                 scopedVariables.insert(name)
+                recentlyAssigned.insert(name)
                 result.append(node)
             case .actionCall(_, _, let output, _):
-                if let output { scopedVariables.insert(output) }
+                if let output {
+                    scopedVariables.insert(output)
+                    recentlyAssigned.insert(output)
+                }
                 result.append(node)
             default:
                 result.append(node)
@@ -88,6 +96,7 @@ struct Preprocessor: Sendable {
         location: SourceLocation,
         scopedVariables: inout Set<String>,
         allProvided: inout [String: String],
+        recentlyAssigned: inout Set<String>,
         includeStack: Set<String>
     ) throws -> [ASTNode] {
         let fileURL = sourceDirectory.appendingPathComponent(path)
@@ -114,12 +123,16 @@ struct Preprocessor: Sendable {
         // Extract #provides and #requires from the fragment
         var provides: Set<String> = []
         var requires: Set<String> = []
+        var freshRequires: Set<String> = []
         for node in fragmentNodes {
             if case .providesDeclaration(let vars, _) = node {
                 for v in vars { provides.insert(v) }
             }
-            if case .requiresDeclaration(let vars, _) = node {
-                for v in vars { requires.insert(v) }
+            if case .requiresDeclaration(let vars, let isFresh, _) = node {
+                for v in vars {
+                    requires.insert(v)
+                    if isFresh { freshRequires.insert(v) }
+                }
             }
         }
 
@@ -132,6 +145,20 @@ struct Preprocessor: Sendable {
                 )
             }
         }
+
+        // Validate #requires fresh: variables were (re-)assigned since the last #include
+        for req in freshRequires {
+            if !recentlyAssigned.contains(req) {
+                throw PreprocessorError(
+                    message: "Fragment '\(path)' requires fresh variable '\(req)' which was not assigned before this include site",
+                    location: location
+                )
+            }
+        }
+
+        // Clear recentlyAssigned after each include so the next include
+        // of a fragment with fresh requires must have fresh assignments.
+        recentlyAssigned.removeAll()
 
         // Check for duplicate #provides
         for prov in provides {
@@ -169,6 +196,7 @@ struct Preprocessor: Sendable {
             nodes: actionNodes,
             scopedVariables: &scopedVariables,
             allProvided: &allProvided,
+            recentlyAssigned: &recentlyAssigned,
             includeStack: childStack
         )
         nestedVars = Self.collectDeclaredVarNames(resolvedNodes).subtracting(ownVarNames)
@@ -215,6 +243,7 @@ struct Preprocessor: Sendable {
         nodes: [ASTNode],
         scopedVariables: inout Set<String>,
         allProvided: inout [String: String],
+        recentlyAssigned: inout Set<String>,
         includeStack: Set<String>
     ) throws -> [ASTNode] {
         var result: [ASTNode] = []
@@ -226,14 +255,19 @@ struct Preprocessor: Sendable {
                     location: location,
                     scopedVariables: &scopedVariables,
                     allProvided: &allProvided,
+                    recentlyAssigned: &recentlyAssigned,
                     includeStack: includeStack
                 )
                 result.append(contentsOf: included)
             case .variableDeclaration(let name, _, _, _):
                 scopedVariables.insert(name)
+                recentlyAssigned.insert(name)
                 result.append(node)
             case .actionCall(_, _, let output, _):
-                if let output { scopedVariables.insert(output) }
+                if let output {
+                    scopedVariables.insert(output)
+                    recentlyAssigned.insert(output)
+                }
                 result.append(node)
             default:
                 result.append(node)
@@ -469,8 +503,8 @@ struct Preprocessor: Sendable {
             return .fragmentMarker(location: stamp(loc, file: file))
         case .providesDeclaration(let vars, let loc):
             return .providesDeclaration(variables: vars, location: stamp(loc, file: file))
-        case .requiresDeclaration(let vars, let loc):
-            return .requiresDeclaration(variables: vars, location: stamp(loc, file: file))
+        case .requiresDeclaration(let vars, let fresh, let loc):
+            return .requiresDeclaration(variables: vars, fresh: fresh, location: stamp(loc, file: file))
         }
     }
 }

--- a/Sources/perspective-cuts/Compiler/Preprocessor.swift
+++ b/Sources/perspective-cuts/Compiler/Preprocessor.swift
@@ -3,12 +3,24 @@ import Foundation
 struct PreprocessorError: Error, CustomStringConvertible {
     let message: String
     let location: SourceLocation?
+    let includeChain: [(file: String, line: Int)]
+
+    init(message: String, location: SourceLocation?, includeChain: [(file: String, line: Int)] = []) {
+        self.message = message
+        self.location = location
+        self.includeChain = includeChain
+    }
 
     var description: String {
+        var desc = "Preprocessor error"
         if let loc = location {
-            return "Preprocessor error at \(loc): \(message)"
+            desc += " at \(loc)"
         }
-        return "Preprocessor error: \(message)"
+        desc += ": \(message)"
+        for site in includeChain {
+            desc += "\n  included from \(site.file):\(site.line)"
+        }
+        return desc
     }
 }
 
@@ -26,7 +38,7 @@ struct Preprocessor: Sendable {
     /// - An included file cannot be found or parsed
     /// - A `#requires` variable is not in scope at the include site
     /// - Two fragments both `#provides` the same variable
-    func preprocess(nodes: [ASTNode], isTopLevel: Bool = true) throws -> [ASTNode] {
+    func preprocess(nodes: [ASTNode], isTopLevel: Bool = true, includeStack: Set<String> = []) throws -> [ASTNode] {
         // Top-level fragment check
         if isTopLevel && nodes.contains(where: { if case .fragmentMarker = $0 { return true } else { return false } }) {
             throw PreprocessorError(
@@ -51,7 +63,8 @@ struct Preprocessor: Sendable {
                     path: path,
                     location: location,
                     scopedVariables: &scopedVariables,
-                    allProvided: &allProvided
+                    allProvided: &allProvided,
+                    includeStack: includeStack
                 )
                 result.append(contentsOf: included)
             case .fragmentMarker, .providesDeclaration, .requiresDeclaration:
@@ -74,12 +87,22 @@ struct Preprocessor: Sendable {
         path: String,
         location: SourceLocation,
         scopedVariables: inout Set<String>,
-        allProvided: inout [String: String]
+        allProvided: inout [String: String],
+        includeStack: Set<String>
     ) throws -> [ASTNode] {
         let fileURL = sourceDirectory.appendingPathComponent(path)
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             throw PreprocessorError(
                 message: "Included file not found: \(path) (resolved to \(fileURL.path))",
+                location: location
+            )
+        }
+
+        // Cycle detection: check if this file is already being processed
+        let canonicalPath = fileURL.standardizedFileURL.path
+        guard !includeStack.contains(canonicalPath) else {
+            throw PreprocessorError(
+                message: "Circular include detected: '\(path)' is already being processed",
                 location: location
             )
         }
@@ -132,6 +155,24 @@ struct Preprocessor: Sendable {
             }
         }
 
+        // Resolve nested #include directives before auto-prefixing.
+        // Use a child preprocessor with the included file's directory for
+        // correct relative path resolution.
+        let childStack = includeStack.union([canonicalPath])
+        let fragmentDir = fileURL.deletingLastPathComponent()
+        let childPreprocessor = Preprocessor(sourceDirectory: fragmentDir)
+        // Track which variable names are introduced by nested includes so we
+        // can exempt them from the parent fragment's auto-prefixing.
+        let ownVarNames = Self.collectDeclaredVarNames(actionNodes)
+        var nestedVars: Set<String> = []
+        let resolvedNodes = try childPreprocessor.resolveNestedIncludes(
+            nodes: actionNodes,
+            scopedVariables: &scopedVariables,
+            allProvided: &allProvided,
+            includeStack: childStack
+        )
+        nestedVars = Self.collectDeclaredVarNames(resolvedNodes).subtracting(ownVarNames)
+
         // Auto-prefix internal variables if fragment has #provides declarations.
         // Variables NOT in #provides and NOT in #requires are internal.
         let hasContracts = !provides.isEmpty || !requires.isEmpty
@@ -139,9 +180,11 @@ struct Preprocessor: Sendable {
         if hasContracts {
             let prefix = fragmentPrefix(from: path)
             let exempt = provides.union(requires)
-            prefixedNodes = prefixNodes(actionNodes, prefix: prefix, exempt: exempt)
+            // Also exempt variables introduced by resolved nested includes
+            // to prevent double-prefixing.
+            prefixedNodes = prefixNodes(resolvedNodes, prefix: prefix, exempt: exempt.union(nestedVars))
         } else {
-            prefixedNodes = actionNodes
+            prefixedNodes = resolvedNodes
         }
 
         // Register provided variables in scope for subsequent fragments
@@ -161,7 +204,59 @@ struct Preprocessor: Sendable {
             }
         }
 
-        return prefixedNodes
+        // Stamp the fragment's file path onto all SourceLocations so error
+        // messages identify which file the code came from.
+        return setFileOnNodes(prefixedNodes, file: path)
+    }
+
+    /// Walks a node list and resolves any `#include` directives, passing
+    /// through all other nodes unchanged.
+    private func resolveNestedIncludes(
+        nodes: [ASTNode],
+        scopedVariables: inout Set<String>,
+        allProvided: inout [String: String],
+        includeStack: Set<String>
+    ) throws -> [ASTNode] {
+        var result: [ASTNode] = []
+        for node in nodes {
+            switch node {
+            case .includeDirective(let path, let location):
+                let included = try resolveInclude(
+                    path: path,
+                    location: location,
+                    scopedVariables: &scopedVariables,
+                    allProvided: &allProvided,
+                    includeStack: includeStack
+                )
+                result.append(contentsOf: included)
+            case .variableDeclaration(let name, _, _, _):
+                scopedVariables.insert(name)
+                result.append(node)
+            case .actionCall(_, _, let output, _):
+                if let output { scopedVariables.insert(output) }
+                result.append(node)
+            default:
+                result.append(node)
+            }
+        }
+        return result
+    }
+
+    /// Collects all variable names declared at the top level of the given nodes.
+    /// Used to build the exempt set for auto-prefixing so that nested fragment
+    /// variables are not double-prefixed by a parent fragment.
+    private static func collectDeclaredVarNames(_ nodes: [ASTNode]) -> Set<String> {
+        var names: Set<String> = []
+        for node in nodes {
+            switch node {
+            case .variableDeclaration(let name, _, _, _):
+                names.insert(name)
+            case .actionCall(_, _, let output, _):
+                if let output { names.insert(output) }
+            default: break
+            }
+        }
+        return names
     }
 
     // MARK: - Fragment Name Prefix
@@ -321,6 +416,61 @@ struct Preprocessor: Sendable {
         case .contains(let l, let r): return .contains(left: px(l), right: px(r))
         case .greaterThan(let l, let r): return .greaterThan(left: px(l), right: px(r))
         case .lessThan(let l, let r): return .lessThan(left: px(l), right: px(r))
+        }
+    }
+
+    // MARK: - Source File Stamping
+
+    /// Rewrites the `SourceLocation.file` on all nodes to the given path,
+    /// unless the node already has a file set (from a deeper nested include).
+    private func setFileOnNodes(_ nodes: [ASTNode], file: String) -> [ASTNode] {
+        nodes.map { setFileOnNode($0, file: file) }
+    }
+
+    private func stamp(_ loc: SourceLocation, file: String) -> SourceLocation {
+        // Don't overwrite if already set by a deeper nested include
+        if loc.file != nil { return loc }
+        return SourceLocation(line: loc.line, column: loc.column, file: file)
+    }
+
+    private func setFileOnNode(_ node: ASTNode, file: String) -> ASTNode {
+        switch node {
+        case .importStatement(let module, let loc):
+            return .importStatement(module: module, location: stamp(loc, file: file))
+        case .metadata(let key, let value, let loc):
+            return .metadata(key: key, value: value, location: stamp(loc, file: file))
+        case .comment(let text, let loc):
+            return .comment(text: text, location: stamp(loc, file: file))
+        case .variableDeclaration(let name, let value, let isConstant, let loc):
+            return .variableDeclaration(name: name, value: value, isConstant: isConstant, location: stamp(loc, file: file))
+        case .actionCall(let name, let arguments, let output, let loc):
+            return .actionCall(name: name, arguments: arguments, output: output, location: stamp(loc, file: file))
+        case .ifStatement(let condition, let thenBody, let elseBody, let loc):
+            return .ifStatement(
+                condition: condition,
+                thenBody: setFileOnNodes(thenBody, file: file),
+                elseBody: elseBody.map { setFileOnNodes($0, file: file) },
+                location: stamp(loc, file: file)
+            )
+        case .repeatLoop(let count, let body, let loc):
+            return .repeatLoop(count: count, body: setFileOnNodes(body, file: file), location: stamp(loc, file: file))
+        case .forEachLoop(let itemName, let collection, let body, let loc):
+            return .forEachLoop(itemName: itemName, collection: collection, body: setFileOnNodes(body, file: file), location: stamp(loc, file: file))
+        case .menu(let title, let cases, let loc):
+            let stamped = cases.map { (label: $0.label, body: setFileOnNodes($0.body, file: file)) }
+            return .menu(title: title, cases: stamped, location: stamp(loc, file: file))
+        case .functionDeclaration(let name, let body, let loc):
+            return .functionDeclaration(name: name, body: setFileOnNodes(body, file: file), location: stamp(loc, file: file))
+        case .returnStatement(let value, let loc):
+            return .returnStatement(value: value, location: stamp(loc, file: file))
+        case .includeDirective(let path, let loc):
+            return .includeDirective(path: path, location: stamp(loc, file: file))
+        case .fragmentMarker(let loc):
+            return .fragmentMarker(location: stamp(loc, file: file))
+        case .providesDeclaration(let vars, let loc):
+            return .providesDeclaration(variables: vars, location: stamp(loc, file: file))
+        case .requiresDeclaration(let vars, let loc):
+            return .requiresDeclaration(variables: vars, location: stamp(loc, file: file))
         }
     }
 }

--- a/Sources/perspective-cuts/Compiler/Preprocessor.swift
+++ b/Sources/perspective-cuts/Compiler/Preprocessor.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct PreprocessorError: Error, CustomStringConvertible {
+    let message: String
+    let location: SourceLocation?
+
+    var description: String {
+        if let loc = location {
+            return "Preprocessor error at \(loc): \(message)"
+        }
+        return "Preprocessor error: \(message)"
+    }
+}
+
+struct Preprocessor: Sendable {
+    /// Directory of the source file being preprocessed, used to resolve
+    /// relative include paths.
+    let sourceDirectory: URL
+
+    /// Resolves all `#include` directives in the given AST by reading,
+    /// parsing, and inlining the referenced files. Strips `importStatement`
+    /// and `metadata` nodes from included content.
+    ///
+    /// Errors if:
+    /// - A `#fragment` file is being compiled as the top-level source
+    /// - An included file cannot be found or parsed
+    func preprocess(nodes: [ASTNode], isTopLevel: Bool = true) throws -> [ASTNode] {
+        // Top-level fragment check
+        if isTopLevel && nodes.contains(where: { if case .fragmentMarker = $0 { return true } else { return false } }) {
+            throw PreprocessorError(
+                message: "Cannot compile a #fragment file directly — it must be #included from another file",
+                location: nodes.first(where: { if case .fragmentMarker = $0 { return true } else { return false } })
+                    .flatMap { if case .fragmentMarker(let loc) = $0 { return loc } else { return nil } }
+            )
+        }
+
+        var result: [ASTNode] = []
+        for node in nodes {
+            switch node {
+            case .includeDirective(let path, let location):
+                let included = try resolveInclude(path: path, location: location)
+                result.append(contentsOf: included)
+            case .fragmentMarker:
+                // Strip #fragment markers — they're metadata for the preprocessor only
+                break
+            default:
+                result.append(node)
+            }
+        }
+        return result
+    }
+
+    private func resolveInclude(path: String, location: SourceLocation) throws -> [ASTNode] {
+        let fileURL = sourceDirectory.appendingPathComponent(path)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw PreprocessorError(
+                message: "Included file not found: \(path) (resolved to \(fileURL.path))",
+                location: location
+            )
+        }
+
+        let source = try String(contentsOf: fileURL, encoding: .utf8)
+        let tokens = try Lexer(source: source).tokenize()
+        let fragmentNodes = try Parser(tokens: tokens).parse()
+
+        // Strip import statements, metadata, and fragment markers from included content
+        let filtered = fragmentNodes.filter { node in
+            switch node {
+            case .importStatement: return false
+            case .metadata: return false
+            case .fragmentMarker: return false
+            default: return true
+            }
+        }
+
+        return filtered
+    }
+}

--- a/Sources/perspective-cuts/Compiler/Preprocessor.swift
+++ b/Sources/perspective-cuts/Compiler/Preprocessor.swift
@@ -186,11 +186,14 @@ struct Preprocessor: Sendable {
     /// Walks the AST and renames all variables that are NOT in the exempt set.
     /// Loop iterator variables (for-each item names) are collected during traversal
     /// and also exempted since they map to Shortcuts "Repeat Item" at runtime.
+    /// Built-in variable names that must never be prefixed.
+    private static let builtInVariables: Set<String> = [Compiler.shortcutInputName]
+
     private func prefixNodes(_ nodes: [ASTNode], prefix: String, exempt: Set<String>) -> [ASTNode] {
         // First pass: collect all for-each loop variable names so they're exempt
         var loopVars: Set<String> = []
         collectLoopVars(nodes, into: &loopVars)
-        let allExempt = exempt.union(loopVars)
+        let allExempt = exempt.union(loopVars).union(Self.builtInVariables)
 
         return nodes.map { prefixNode($0, prefix: prefix, exempt: allExempt) }
     }

--- a/Sources/perspective-cuts/Compiler/SiriTimeoutAnalyzer.swift
+++ b/Sources/perspective-cuts/Compiler/SiriTimeoutAnalyzer.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// Analyzes a shortcut's AST to detect code paths where a potentially slow action
+/// runs without a preceding output-producing action, which can trigger Siri's
+/// ~4-5 second timeout when invoked via "Hey Siri."
+///
+/// This is a heuristic check — false positives are expected. The goal is to remind
+/// the author to add early output, not to guarantee correctness.
+///
+/// See: https://github.com/akostibas/perspective-cuts/issues/4
+struct SiriTimeoutAnalyzer {
+
+    struct Diagnostic: CustomStringConvertible {
+        let actionName: String
+        let location: SourceLocation
+        let branchContext: String?
+
+        var description: String {
+            let reachability = branchContext.map { "reachable \($0)" } ?? "always reachable"
+            return "\(location): \(actionName) may be slow with no prior output — \(reachability)"
+        }
+    }
+
+    let registry: ActionRegistry
+
+    /// Actions known to be potentially slow (network, external processes, etc.)
+    static let potentiallySlowActions: Set<String> = [
+        "downloadURL",
+        "getContentsOfUrl",
+        "getContentsOfURL",
+        "runShortcut",
+        "runSSHScript",
+        "getWebPageContents",
+        "getRSSFeed",
+        "searchAppStore",
+        "searchITunes",
+        "searchLocalBusinesses",
+        "getCurrentLocation",
+        "getDirections",
+        "getTravelTime",
+        "useModel",
+        "translateText",
+    ]
+
+    /// Corresponding ToolKit identifiers for the above
+    static let potentiallySlowIdentifiers: Set<String> = [
+        "is.workflow.actions.downloadurl",
+        "is.workflow.actions.getcontentsofurl",
+        "is.workflow.actions.runworkflow",
+        "is.workflow.actions.runsshscript",
+        "is.workflow.actions.getwebpagecontents",
+        "is.workflow.actions.rss",
+        "is.workflow.actions.searchappstore",
+        "is.workflow.actions.searchitunes",
+        "is.workflow.actions.searchlocalbusinesses",
+        "is.workflow.actions.getcurrentlocation",
+        "is.workflow.actions.getdirections",
+        "is.workflow.actions.gettraveltime",
+        "is.workflow.actions.usemodel",
+        "is.workflow.actions.translatetext",
+    ]
+
+    /// Actions that produce visible output (satisfying Siri's timeout)
+    static let outputProducingActions: Set<String> = [
+        "showResult",
+        "alert",
+        "ask",
+        "speakText",
+    ]
+
+    static let outputProducingIdentifiers: Set<String> = [
+        "is.workflow.actions.showresult",
+        "is.workflow.actions.alert",
+        "is.workflow.actions.ask",
+        "is.workflow.actions.speaktext",
+    ]
+
+    func analyze(nodes: [ASTNode]) -> [Diagnostic] {
+        var diagnostics: [Diagnostic] = []
+        walkPath(nodes: nodes, hasOutput: false, branchContext: nil, diagnostics: &diagnostics)
+        return diagnostics
+    }
+
+    // MARK: - Private
+
+    /// Walks nodes sequentially, tracking whether output has been produced on this path.
+    private func walkPath(nodes: [ASTNode], hasOutput: Bool, branchContext: String?, diagnostics: inout [Diagnostic]) {
+        var hasOutput = hasOutput
+
+        for node in nodes {
+            switch node {
+            case .actionCall(let name, _, _, let location):
+                if !hasOutput && isPotentiallySlow(name) {
+                    diagnostics.append(Diagnostic(
+                        actionName: name,
+                        location: location,
+                        branchContext: branchContext
+                    ))
+                }
+                if producesOutput(name) {
+                    hasOutput = true
+                }
+
+            case .ifStatement(let condition, let thenBody, let elseBody, _):
+                let condStr = ASTWalker.describeCondition(condition)
+                walkPath(
+                    nodes: thenBody,
+                    hasOutput: hasOutput,
+                    branchContext: ASTWalker.composeContext(branchContext, "when \(condStr)"),
+                    diagnostics: &diagnostics
+                )
+                if let elseBody {
+                    walkPath(
+                        nodes: elseBody,
+                        hasOutput: hasOutput,
+                        branchContext: ASTWalker.composeContext(branchContext, "when not (\(condStr))"),
+                        diagnostics: &diagnostics
+                    )
+                }
+
+            case .menu(let title, let cases, _):
+                for menuCase in cases {
+                    let caseContext = "in menu \"\(title)\" case \"\(menuCase.label)\""
+                    walkPath(
+                        nodes: menuCase.body,
+                        hasOutput: hasOutput,
+                        branchContext: ASTWalker.composeContext(branchContext, caseContext),
+                        diagnostics: &diagnostics
+                    )
+                }
+
+            case .repeatLoop(_, let body, _):
+                walkPath(nodes: body, hasOutput: hasOutput, branchContext: branchContext, diagnostics: &diagnostics)
+
+            case .forEachLoop(_, _, let body, _):
+                walkPath(nodes: body, hasOutput: hasOutput, branchContext: branchContext, diagnostics: &diagnostics)
+
+            case .functionDeclaration(_, let body, _):
+                walkPath(nodes: body, hasOutput: hasOutput, branchContext: branchContext, diagnostics: &diagnostics)
+
+            default:
+                break
+            }
+        }
+    }
+
+    private func isPotentiallySlow(_ name: String) -> Bool {
+        if Self.potentiallySlowActions.contains(name) { return true }
+        // 3rd-party actions: check identifier directly
+        if name.contains(".") { return Self.potentiallySlowIdentifiers.contains(name) }
+        // Check via registry identifier
+        if let def = registry.actions[name] {
+            return Self.potentiallySlowIdentifiers.contains(def.identifier)
+        }
+        return false
+    }
+
+    private func producesOutput(_ name: String) -> Bool {
+        if Self.outputProducingActions.contains(name) { return true }
+        if name.contains(".") { return Self.outputProducingIdentifiers.contains(name) }
+        if let def = registry.actions[name] {
+            return Self.outputProducingIdentifiers.contains(def.identifier)
+        }
+        return false
+    }
+}

--- a/Sources/perspective-cuts/Compiler/StandaloneAnalyzer.swift
+++ b/Sources/perspective-cuts/Compiler/StandaloneAnalyzer.swift
@@ -33,60 +33,26 @@ struct StandaloneAnalyzer {
 
     func analyze(nodes: [ASTNode]) -> [Diagnostic] {
         var diagnostics: [Diagnostic] = []
-        walk(nodes: nodes, branchContext: nil, diagnostics: &diagnostics)
-        return diagnostics
-    }
-
-    // MARK: - Private
-
-    private func walk(nodes: [ASTNode], branchContext: String?, diagnostics: inout [Diagnostic]) {
-        for node in nodes {
-            switch node {
-            case .actionCall(let name, let arguments, _, let location):
-                // Dotted names are 3rd-party app actions
-                if name.contains(".") {
-                    diagnostics.append(Diagnostic(
-                        dependency: .thirdPartyApp(identifier: name),
-                        location: location,
-                        branchContext: branchContext
-                    ))
-                }
-                // runShortcut depends on another shortcut
-                if name == "runShortcut" {
-                    let shortcutName = extractShortcutName(from: arguments)
-                    diagnostics.append(Diagnostic(
-                        dependency: .shortcut(name: shortcutName),
-                        location: location,
-                        branchContext: branchContext
-                    ))
-                }
-
-            case .ifStatement(let condition, let thenBody, let elseBody, _):
-                let condStr = describeCondition(condition)
-                walk(nodes: thenBody, branchContext: composeContext(branchContext, "when \(condStr)"), diagnostics: &diagnostics)
-                if let elseBody {
-                    walk(nodes: elseBody, branchContext: composeContext(branchContext, "when not (\(condStr))"), diagnostics: &diagnostics)
-                }
-
-            case .menu(let title, let cases, _):
-                for menuCase in cases {
-                    let caseContext = "in menu \"\(title)\" case \"\(menuCase.label)\""
-                    walk(nodes: menuCase.body, branchContext: composeContext(branchContext, caseContext), diagnostics: &diagnostics)
-                }
-
-            case .repeatLoop(_, let body, _):
-                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
-
-            case .forEachLoop(_, _, let body, _):
-                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
-
-            case .functionDeclaration(_, let body, _):
-                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
-
-            default:
-                break
+        ASTWalker.walk(nodes: nodes) { visit in
+            // Dotted names are 3rd-party app actions
+            if visit.name.contains(".") {
+                diagnostics.append(Diagnostic(
+                    dependency: .thirdPartyApp(identifier: visit.name),
+                    location: visit.location,
+                    branchContext: visit.branchContext
+                ))
+            }
+            // runShortcut depends on another shortcut
+            if visit.name == "runShortcut" {
+                let shortcutName = extractShortcutName(from: visit.arguments)
+                diagnostics.append(Diagnostic(
+                    dependency: .shortcut(name: shortcutName),
+                    location: visit.location,
+                    branchContext: visit.branchContext
+                ))
             }
         }
+        return diagnostics
     }
 
     private func extractShortcutName(from arguments: [(label: String?, value: Expression)]) -> String {
@@ -100,41 +66,8 @@ struct StandaloneAnalyzer {
         // (DependencyKind.description already wraps in quotes)
         switch expr {
         case .stringLiteral(let s): return s
-        case let e?: return describeExpr(e)
+        case let e?: return ASTWalker.describeExpr(e)
         case nil: return "<unknown>"
-        }
-    }
-
-    private func composeContext(_ existing: String?, _ new: String) -> String {
-        if let existing {
-            return "\(existing), \(new)"
-        }
-        return new
-    }
-
-    private func describeCondition(_ condition: Condition) -> String {
-        switch condition {
-        case .equals(let left, let right):
-            return "\(describeExpr(left)) == \(describeExpr(right))"
-        case .notEquals(let left, let right):
-            return "\(describeExpr(left)) != \(describeExpr(right))"
-        case .contains(let left, let right):
-            return "\(describeExpr(left)) contains \(describeExpr(right))"
-        case .greaterThan(let left, let right):
-            return "\(describeExpr(left)) > \(describeExpr(right))"
-        case .lessThan(let left, let right):
-            return "\(describeExpr(left)) < \(describeExpr(right))"
-        }
-    }
-
-    private func describeExpr(_ expr: Expression) -> String {
-        switch expr {
-        case .stringLiteral(let s): return "\"\(s)\""
-        case .numberLiteral(let n): return n.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(n)) : String(n)
-        case .boolLiteral(let b): return String(b)
-        case .variableReference(let v): return v
-        case .interpolatedString: return "<interpolated string>"
-        case .dictionaryLiteral: return "<dictionary>"
         }
     }
 }

--- a/Sources/perspective-cuts/Compiler/StandaloneAnalyzer.swift
+++ b/Sources/perspective-cuts/Compiler/StandaloneAnalyzer.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Analyzes a shortcut's AST to determine whether it can run independently,
+/// without other shortcuts or third-party apps installed.
+///
+/// See: https://github.com/akostibas/perspective-cuts/issues/5
+struct StandaloneAnalyzer {
+
+    enum DependencyKind: CustomStringConvertible {
+        case shortcut(name: String)
+        case thirdPartyApp(identifier: String)
+
+        var description: String {
+            switch self {
+            case .shortcut(let name): return "shortcut \"\(name)\""
+            case .thirdPartyApp(let id): return "3rd-party action \(id)"
+            }
+        }
+    }
+
+    struct Diagnostic: CustomStringConvertible {
+        let dependency: DependencyKind
+        let location: SourceLocation
+        let branchContext: String?
+
+        var description: String {
+            let reachability = branchContext.map { "reachable \($0)" } ?? "always reachable"
+            return "\(location): \(dependency) — \(reachability)"
+        }
+    }
+
+    let registry: ActionRegistry
+
+    func analyze(nodes: [ASTNode]) -> [Diagnostic] {
+        var diagnostics: [Diagnostic] = []
+        walk(nodes: nodes, branchContext: nil, diagnostics: &diagnostics)
+        return diagnostics
+    }
+
+    // MARK: - Private
+
+    private func walk(nodes: [ASTNode], branchContext: String?, diagnostics: inout [Diagnostic]) {
+        for node in nodes {
+            switch node {
+            case .actionCall(let name, let arguments, _, let location):
+                // Dotted names are 3rd-party app actions
+                if name.contains(".") {
+                    diagnostics.append(Diagnostic(
+                        dependency: .thirdPartyApp(identifier: name),
+                        location: location,
+                        branchContext: branchContext
+                    ))
+                }
+                // runShortcut depends on another shortcut
+                if name == "runShortcut" {
+                    let shortcutName = extractShortcutName(from: arguments)
+                    diagnostics.append(Diagnostic(
+                        dependency: .shortcut(name: shortcutName),
+                        location: location,
+                        branchContext: branchContext
+                    ))
+                }
+
+            case .ifStatement(let condition, let thenBody, let elseBody, _):
+                let condStr = describeCondition(condition)
+                walk(nodes: thenBody, branchContext: composeContext(branchContext, "when \(condStr)"), diagnostics: &diagnostics)
+                if let elseBody {
+                    walk(nodes: elseBody, branchContext: composeContext(branchContext, "when not (\(condStr))"), diagnostics: &diagnostics)
+                }
+
+            case .menu(let title, let cases, _):
+                for menuCase in cases {
+                    let caseContext = "in menu \"\(title)\" case \"\(menuCase.label)\""
+                    walk(nodes: menuCase.body, branchContext: composeContext(branchContext, caseContext), diagnostics: &diagnostics)
+                }
+
+            case .repeatLoop(_, let body, _):
+                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
+
+            case .forEachLoop(_, _, let body, _):
+                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
+
+            case .functionDeclaration(_, let body, _):
+                walk(nodes: body, branchContext: branchContext, diagnostics: &diagnostics)
+
+            default:
+                break
+            }
+        }
+    }
+
+    private func extractShortcutName(from arguments: [(label: String?, value: Expression)]) -> String {
+        let expr: Expression?
+        if let named = arguments.first(where: { $0.label == "name" }) {
+            expr = named.value
+        } else {
+            expr = arguments.first?.value
+        }
+        // Extract raw string for string literals to avoid double-quoting
+        // (DependencyKind.description already wraps in quotes)
+        switch expr {
+        case .stringLiteral(let s): return s
+        case let e?: return describeExpr(e)
+        case nil: return "<unknown>"
+        }
+    }
+
+    private func composeContext(_ existing: String?, _ new: String) -> String {
+        if let existing {
+            return "\(existing), \(new)"
+        }
+        return new
+    }
+
+    private func describeCondition(_ condition: Condition) -> String {
+        switch condition {
+        case .equals(let left, let right):
+            return "\(describeExpr(left)) == \(describeExpr(right))"
+        case .notEquals(let left, let right):
+            return "\(describeExpr(left)) != \(describeExpr(right))"
+        case .contains(let left, let right):
+            return "\(describeExpr(left)) contains \(describeExpr(right))"
+        case .greaterThan(let left, let right):
+            return "\(describeExpr(left)) > \(describeExpr(right))"
+        case .lessThan(let left, let right):
+            return "\(describeExpr(left)) < \(describeExpr(right))"
+        }
+    }
+
+    private func describeExpr(_ expr: Expression) -> String {
+        switch expr {
+        case .stringLiteral(let s): return "\"\(s)\""
+        case .numberLiteral(let n): return n.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(n)) : String(n)
+        case .boolLiteral(let b): return String(b)
+        case .variableReference(let v): return v
+        case .interpolatedString: return "<interpolated string>"
+        case .dictionaryLiteral: return "<dictionary>"
+        }
+    }
+}

--- a/Sources/perspective-cuts/Lexer/Token.swift
+++ b/Sources/perspective-cuts/Lexer/Token.swift
@@ -3,8 +3,20 @@ import Foundation
 struct SourceLocation: Sendable, CustomStringConvertible {
     let line: Int
     let column: Int
+    let file: String?
 
-    var description: String { "line \(line), column \(column)" }
+    init(line: Int, column: Int, file: String? = nil) {
+        self.line = line
+        self.column = column
+        self.file = file
+    }
+
+    var description: String {
+        if let file {
+            return "\(file):line \(line), column \(column)"
+        }
+        return "line \(line), column \(column)"
+    }
 }
 
 enum TokenKind: Sendable, Equatable {

--- a/Sources/perspective-cuts/Parser/AST.swift
+++ b/Sources/perspective-cuts/Parser/AST.swift
@@ -18,6 +18,9 @@ enum ASTNode: Sendable {
 
     case functionDeclaration(name: String, body: [ASTNode], location: SourceLocation)
     case returnStatement(value: Expression?, location: SourceLocation)
+
+    case includeDirective(path: String, location: SourceLocation)
+    case fragmentMarker(location: SourceLocation)
 }
 
 struct DictionaryEntry: Sendable {

--- a/Sources/perspective-cuts/Parser/AST.swift
+++ b/Sources/perspective-cuts/Parser/AST.swift
@@ -21,6 +21,8 @@ enum ASTNode: Sendable {
 
     case includeDirective(path: String, location: SourceLocation)
     case fragmentMarker(location: SourceLocation)
+    case providesDeclaration(variables: [String], location: SourceLocation)
+    case requiresDeclaration(variables: [String], location: SourceLocation)
 }
 
 struct DictionaryEntry: Sendable {

--- a/Sources/perspective-cuts/Parser/AST.swift
+++ b/Sources/perspective-cuts/Parser/AST.swift
@@ -22,7 +22,7 @@ enum ASTNode: Sendable {
     case includeDirective(path: String, location: SourceLocation)
     case fragmentMarker(location: SourceLocation)
     case providesDeclaration(variables: [String], location: SourceLocation)
-    case requiresDeclaration(variables: [String], location: SourceLocation)
+    case requiresDeclaration(variables: [String], fresh: Bool, location: SourceLocation)
 }
 
 struct DictionaryEntry: Sendable {

--- a/Sources/perspective-cuts/Parser/Parser.swift
+++ b/Sources/perspective-cuts/Parser/Parser.swift
@@ -98,6 +98,20 @@ struct Parser: Sendable {
             return .fragmentMarker(location: loc)
         }
 
+        // #provides: var1, var2, var3
+        if key == "provides" {
+            pos += 1 // skip 'provides'
+            let vars = try parseCommaIdentifierList(&pos, directive: "provides", location: loc)
+            return .providesDeclaration(variables: vars, location: loc)
+        }
+
+        // #requires: var1, var2, var3
+        if key == "requires" {
+            pos += 1 // skip 'requires'
+            let vars = try parseCommaIdentifierList(&pos, directive: "requires", location: loc)
+            return .requiresDeclaration(variables: vars, location: loc)
+        }
+
         pos += 1
         guard pos < tokens.count, tokens[pos].kind == .colon else {
             throw ParserError(message: "Expected ':' after metadata key", location: tokens[pos].location)
@@ -514,6 +528,35 @@ struct Parser: Sendable {
             parts.append(.text(current))
         }
         return parts
+    }
+
+    /// Parses `: ident, ident, ident` after a directive keyword like `#provides` or `#requires`.
+    private func parseCommaIdentifierList(_ pos: inout Int, directive: String, location: SourceLocation) throws -> [String] {
+        guard pos < tokens.count, tokens[pos].kind == .colon else {
+            throw ParserError(message: "Expected ':' after '#\(directive)'", location: tokens[pos].location)
+        }
+        pos += 1 // skip :
+        var names: [String] = []
+        while pos < tokens.count {
+            switch tokens[pos].kind {
+            case .identifier(let name):
+                names.append(name)
+                pos += 1
+            case .comma:
+                pos += 1
+                continue
+            default:
+                break
+            }
+            if pos < tokens.count, case .comma = tokens[pos].kind {
+                continue
+            }
+            break
+        }
+        guard !names.isEmpty else {
+            throw ParserError(message: "Expected at least one variable name after '#\(directive):'", location: location)
+        }
+        return names
     }
 
     private func skipNewlines(_ pos: inout Int) {

--- a/Sources/perspective-cuts/Parser/Parser.swift
+++ b/Sources/perspective-cuts/Parser/Parser.swift
@@ -106,10 +106,16 @@ struct Parser: Sendable {
         }
 
         // #requires: var1, var2, var3
+        // #requires fresh: var1, var2, var3
         if key == "requires" {
             pos += 1 // skip 'requires'
+            var fresh = false
+            if pos < tokens.count, case .identifier("fresh") = tokens[pos].kind {
+                fresh = true
+                pos += 1 // skip 'fresh'
+            }
             let vars = try parseCommaIdentifierList(&pos, directive: "requires", location: loc)
-            return .requiresDeclaration(variables: vars, location: loc)
+            return .requiresDeclaration(variables: vars, fresh: fresh, location: loc)
         }
 
         pos += 1

--- a/Sources/perspective-cuts/Parser/Parser.swift
+++ b/Sources/perspective-cuts/Parser/Parser.swift
@@ -81,6 +81,23 @@ struct Parser: Sendable {
         guard pos < tokens.count, case .identifier(let key) = tokens[pos].kind else {
             throw ParserError(message: "Expected metadata key after '#'", location: loc)
         }
+
+        // #include "path"
+        if key == "include" {
+            pos += 1 // skip 'include'
+            guard pos < tokens.count, case .stringLiteral(let path) = tokens[pos].kind else {
+                throw ParserError(message: "Expected string path after '#include'", location: tokens[pos].location)
+            }
+            pos += 1
+            return .includeDirective(path: path, location: loc)
+        }
+
+        // #fragment
+        if key == "fragment" {
+            pos += 1 // skip 'fragment'
+            return .fragmentMarker(location: loc)
+        }
+
         pos += 1
         guard pos < tokens.count, tokens[pos].kind == .colon else {
             throw ParserError(message: "Expected ':' after metadata key", location: tokens[pos].location)

--- a/Sources/perspective-cuts/Registry/ActionRegistry.swift
+++ b/Sources/perspective-cuts/Registry/ActionRegistry.swift
@@ -54,16 +54,21 @@ struct ActionRegistry: Sendable {
                 return URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent()
             }()
 
-            // 1. Next to executable
+            // 1. SPM resource bundle (preferred — embedded at build time)
+            if let bundled = Bundle.module.url(forResource: "actions", withExtension: "json") {
+                urls.append(bundled)
+            }
+
+            // 2. Next to executable (legacy / Homebrew)
             urls.append(execDir.appendingPathComponent("actions.json"))
 
-            // 2. Homebrew Cellar layout: <prefix>/bin/perspective-cuts -> <prefix>/Resources/actions.json
+            // 3. Homebrew Cellar layout: <prefix>/bin/perspective-cuts -> <prefix>/Resources/actions.json
             urls.append(execDir.deletingLastPathComponent().appendingPathComponent("Resources/actions.json"))
 
-            // 3. SPM resource bundle (swift run in development)
+            // 4. SPM resource bundle sidecar (swift run in development)
             urls.append(execDir.appendingPathComponent("perspective-cuts_perspective-cuts.bundle/actions.json"))
 
-            // 4. Bundle.main fallback
+            // 5. Bundle.main fallback
             if let bundleURL = Bundle.main.url(forResource: "actions", withExtension: "json", subdirectory: nil) {
                 urls.append(bundleURL)
             }

--- a/Sources/perspective-cuts/Registry/ActionRegistry.swift
+++ b/Sources/perspective-cuts/Registry/ActionRegistry.swift
@@ -9,13 +9,20 @@ struct ActionParameter: Sendable {
     let key: String
     let values: [String]?
     let valueMap: [String: Int]?
+    /// Optional coercion hint emitted as a WFCoercionVariableAggrandizement on
+    /// the parameter's WFInput. Used when an action needs Shortcuts to read a
+    /// File's text content rather than the File object itself — e.g.
+    /// `getDictionary` on a downloadURL response. Currently supports "string"
+    /// (→ WFStringContentItem).
+    let coerce: String?
 
-    init(type: String, required: Bool, key: String, values: [String]? = nil, valueMap: [String: Int]? = nil) {
+    init(type: String, required: Bool, key: String, values: [String]? = nil, valueMap: [String: Int]? = nil, coerce: String? = nil) {
         self.type = type
         self.required = required
         self.key = key
         self.values = values
         self.valueMap = valueMap
+        self.coerce = coerce
     }
 }
 
@@ -103,7 +110,8 @@ struct ActionRegistry: Sendable {
                             required: paramDef["required"] as? Bool ?? false,
                             key: paramDef["key"] as? String ?? paramName,
                             values: paramDef["values"] as? [String],
-                            valueMap: paramDef["values"] as? [String: Int]
+                            valueMap: paramDef["values"] as? [String: Int],
+                            coerce: paramDef["coerce"] as? String
                         )
                     }
                 }

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -198,7 +198,7 @@
           "key": "WFHTTPBodyType"
         },
         "body": {
-          "type": "dictionary",
+          "type": "variable",
           "required": false,
           "key": "WFRequestVariable"
         }

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -1168,12 +1168,17 @@
     },
     "exitShortcut": {
       "identifier": "is.workflow.actions.exit",
-      "description": "Stop and output a result",
+      "description": "Stop this shortcut without returning a result",
+      "parameters": {}
+    },
+    "outputShortcut": {
+      "identifier": "is.workflow.actions.output",
+      "description": "Stop and output a result to the caller",
       "parameters": {
         "result": {
-          "type": "variable",
-          "required": false,
-          "key": "WFResult"
+          "type": "string",
+          "required": true,
+          "key": "WFOutput"
         }
       }
     },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -1055,7 +1055,7 @@
       "description": "Run another shortcut",
       "parameters": {
         "name": {
-          "type": "string",
+          "type": "plainString",
           "required": true,
           "key": "WFWorkflowName"
         },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -884,6 +884,16 @@
           "type": "boolean",
           "required": false,
           "key": "SelectMultiple"
+        },
+        "path": {
+          "type": "string",
+          "required": false,
+          "key": "WFGetFilePath"
+        },
+        "errorIfNotFound": {
+          "type": "boolean",
+          "required": false,
+          "key": "WFFileErrorIfNotFound"
         }
       }
     },
@@ -905,6 +915,11 @@
           "type": "boolean",
           "required": false,
           "key": "WFSaveFileOverwrite"
+        },
+        "askWhere": {
+          "type": "boolean",
+          "required": false,
+          "key": "WFAskWhereToSave"
         }
       }
     },
@@ -1055,7 +1070,7 @@
       "description": "Run another shortcut",
       "parameters": {
         "name": {
-          "type": "plainString",
+          "type": "variable",
           "required": true,
           "key": "WFWorkflowName"
         },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -355,7 +355,7 @@
           "key": "WFInput"
         },
         "specifier": {
-          "type": "string",
+          "type": "plainString",
           "required": false,
           "key": "WFItemSpecifier"
         },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -843,6 +843,17 @@
     "getCurrentLocation": {
       "identifier": "is.workflow.actions.getcurrentlocation",
       "description": "Get current GPS location",
+      "parameters": {
+        "accuracy": {
+          "type": "enum",
+          "required": false,
+          "key": "Accuracy"
+        }
+      }
+    },
+    "getCurrentApp": {
+      "identifier": "is.workflow.actions.getcurrentapp",
+      "description": "Get the name of the current foreground app",
       "parameters": {}
     },
     "getDistance": {

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -201,6 +201,11 @@
           "type": "variable",
           "required": false,
           "key": "WFRequestVariable"
+        },
+        "formValues": {
+          "type": "formDictionary",
+          "required": false,
+          "key": "WFFormValues"
         }
       }
     },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -928,6 +928,27 @@
         }
       }
     },
+    "appendToFile": {
+      "identifier": "is.workflow.actions.file.append",
+      "description": "Append text to a file in the Shortcuts folder",
+      "parameters": {
+        "input": {
+          "type": "string",
+          "required": true,
+          "key": "WFInput"
+        },
+        "filePath": {
+          "type": "string",
+          "required": true,
+          "key": "WFFilePath"
+        },
+        "makeNewLine": {
+          "type": "boolean",
+          "required": false,
+          "key": "WFAppendOnNewLine"
+        }
+      }
+    },
     "getFileLink": {
       "identifier": "is.workflow.actions.file.getlink",
       "description": "Get a sharing link for a file",

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -910,6 +910,11 @@
           "type": "boolean",
           "required": false,
           "key": "WFFileErrorIfNotFound"
+        },
+        "folder": {
+          "type": "iCloudFolder",
+          "required": false,
+          "key": "WFFile"
         }
       }
     },
@@ -936,6 +941,11 @@
           "type": "boolean",
           "required": false,
           "key": "WFAskWhereToSave"
+        },
+        "folder": {
+          "type": "iCloudFolder",
+          "required": false,
+          "key": "WFFolder"
         }
       }
     },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -546,14 +546,9 @@
           "key": "text"
         },
         "separator": {
-          "type": "string",
+          "type": "textSeparator",
           "required": false,
           "key": "WFTextSeparator"
-        },
-        "customSeparator": {
-          "type": "string",
-          "required": false,
-          "key": "WFTextCustomSeparator"
         }
       }
     },
@@ -567,14 +562,9 @@
           "key": "text"
         },
         "separator": {
-          "type": "string",
+          "type": "textSeparator",
           "required": false,
           "key": "WFTextSeparator"
-        },
-        "customSeparator": {
-          "type": "string",
-          "required": false,
-          "key": "WFTextCustomSeparator"
         }
       }
     },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -1764,7 +1764,8 @@
         "input": {
           "type": "variable",
           "required": true,
-          "key": "WFInput"
+          "key": "WFInput",
+          "coerce": "string"
         }
       }
     },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -510,7 +510,7 @@
       "description": "Replace text in a string",
       "parameters": {
         "input": {
-          "type": "variable",
+          "type": "string",
           "required": true,
           "key": "WFInput"
         },
@@ -744,7 +744,7 @@
           "key": "WFDate"
         },
         "style": {
-          "type": "string",
+          "type": "plainString",
           "required": false,
           "key": "WFDateFormatStyle"
         },

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -739,7 +739,7 @@
       "description": "Format a date as text",
       "parameters": {
         "date": {
-          "type": "variable",
+          "type": "string",
           "required": true,
           "key": "WFDate"
         },

--- a/Tests/CompilerTests.swift
+++ b/Tests/CompilerTests.swift
@@ -37,6 +37,27 @@ func declaredVariableCompiles() throws {
     #expect(actions.count == 2)
 }
 
+@Test("shortcutInput is pre-declared and emits ExtensionInput")
+func shortcutInputCompiles() throws {
+    let source = """
+    showResult(text: "\\(shortcutInput)")
+    """
+    let tokens = try Lexer(source: source).tokenize()
+    let nodes = try Parser(tokens: tokens).parse()
+    let result = try Compiler(registry: testRegistry()).compile(nodes: nodes)
+
+    let actions = result["WFWorkflowActions"] as! [[String: Any]]
+    #expect(actions.count == 1)
+
+    // Verify the interpolation emits ExtensionInput attachment
+    let params = actions[0]["WFWorkflowActionParameters"] as! [String: Any]
+    let text = params["Text"] as! [String: Any]
+    let value = text["Value"] as! [String: Any]
+    let attachments = value["attachmentsByRange"] as! [String: Any]
+    let attachment = attachments["{0, 1}"] as! [String: Any]
+    #expect(attachment["Type"] as? String == "ExtensionInput")
+}
+
 @Test("Undeclared variable reference produces compile error")
 func undeclaredVariableThrows() throws {
     let source = """

--- a/Tests/CompilerTests.swift
+++ b/Tests/CompilerTests.swift
@@ -1,7 +1,10 @@
 import Testing
 @testable import perspective_cuts
 
-/// Minimal registry with just the actions needed for tests.
+@Suite("Compiler")
+struct CompilerTests {
+
+/// Minimal registry with actions needed for tests.
 private func testRegistry() -> ActionRegistry {
     ActionRegistry(
         actions: [
@@ -17,41 +20,65 @@ private func testRegistry() -> ActionRegistry {
                     "text": ActionParameter(type: "string", required: true, key: "Text")
                 ]
             ),
+            "setVariable": ActionDefinition(
+                identifier: "is.workflow.actions.setvariable",
+                description: "Set a variable",
+                parameters: [
+                    "name": ActionParameter(type: "plainString", required: true, key: "WFVariableName"),
+                    "input": ActionParameter(type: "variable", required: true, key: "WFInput")
+                ]
+            ),
+            "getFile": ActionDefinition(
+                identifier: "is.workflow.actions.documentpicker.open",
+                description: "Get file",
+                parameters: [
+                    "path": ActionParameter(type: "plainString", required: false, key: "WFGetFilePath"),
+                    "errorIfNotFound": ActionParameter(type: "boolean", required: false, key: "WFFileErrorIfNotFound")
+                ]
+            ),
         ],
         controlFlow: [:],
-        iconColors: [:]
+        iconColors: ["blue": 463140863, "red": 4271458559]
     )
 }
 
-@Test("Declared variable references compile successfully")
-func declaredVariableCompiles() throws {
-    let source = """
-    getBattery() -> level
-    showResult(text: "\\(level)")
-    """
+private func compile(_ source: String) throws -> [String: Any] {
     let tokens = try Lexer(source: source).tokenize()
     let nodes = try Parser(tokens: tokens).parse()
-    let result = try Compiler(registry: testRegistry()).compile(nodes: nodes)
+    return try Compiler(registry: testRegistry()).compile(nodes: nodes)
+}
 
-    let actions = result["WFWorkflowActions"] as! [[String: Any]]
-    #expect(actions.count == 2)
+private func actions(from result: [String: Any]) -> [[String: Any]] {
+    result["WFWorkflowActions"] as! [[String: Any]]
+}
+
+private func params(of action: [String: Any]) -> [String: Any] {
+    action["WFWorkflowActionParameters"] as! [String: Any]
+}
+
+private func identifier(of action: [String: Any]) -> String {
+    action["WFWorkflowActionIdentifier"] as! String
+}
+
+// MARK: - Variable References (existing tests, expanded)
+
+@Test("Declared variable references compile successfully")
+func declaredVariableCompiles() throws {
+    let result = try compile("""
+    getBattery() -> level
+    showResult(text: "\\(level)")
+    """)
+    #expect(actions(from: result).count == 2)
 }
 
 @Test("shortcutInput is pre-declared and emits ExtensionInput")
 func shortcutInputCompiles() throws {
-    let source = """
-    showResult(text: "\\(shortcutInput)")
-    """
-    let tokens = try Lexer(source: source).tokenize()
-    let nodes = try Parser(tokens: tokens).parse()
-    let result = try Compiler(registry: testRegistry()).compile(nodes: nodes)
+    let result = try compile("showResult(text: \"\\(shortcutInput)\")")
+    let acts = actions(from: result)
+    #expect(acts.count == 1)
 
-    let actions = result["WFWorkflowActions"] as! [[String: Any]]
-    #expect(actions.count == 1)
-
-    // Verify the interpolation emits ExtensionInput attachment
-    let params = actions[0]["WFWorkflowActionParameters"] as! [String: Any]
-    let text = params["Text"] as! [String: Any]
+    let p = params(of: acts[0])
+    let text = p["Text"] as! [String: Any]
     let value = text["Value"] as! [String: Any]
     let attachments = value["attachmentsByRange"] as! [String: Any]
     let attachment = attachments["{0, 1}"] as! [String: Any]
@@ -60,13 +87,458 @@ func shortcutInputCompiles() throws {
 
 @Test("Undeclared variable reference produces compile error")
 func undeclaredVariableThrows() throws {
-    let source = """
-    showResult(text: "\\(bogusVar)")
-    """
-    let tokens = try Lexer(source: source).tokenize()
-    let nodes = try Parser(tokens: tokens).parse()
-
     #expect(throws: CompilerError.self) {
-        _ = try Compiler(registry: testRegistry()).compile(nodes: nodes)
+        _ = try compile("showResult(text: \"\\(bogusVar)\")")
     }
 }
+
+// MARK: - Action Calls
+
+@Test("Action call emits correct identifier")
+func actionCallIdentifier() throws {
+    let result = try compile("getBattery()")
+    let acts = actions(from: result)
+    #expect(acts.count == 1)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.getbatterylevel")
+}
+
+@Test("Action call with labeled parameter maps to plist key")
+func actionCallParameter() throws {
+    let result = try compile("showResult(text: \"hello\")")
+    let acts = actions(from: result)
+    let p = params(of: acts[0])
+    // "text" parameter maps to plist key "Text"
+    #expect(p["Text"] != nil)
+}
+
+@Test("Unknown action produces compile error with suggestion")
+func unknownActionError() throws {
+    #expect(throws: CompilerError.self) {
+        _ = try compile("getBatery()")
+    }
+}
+
+// MARK: - Output Captures (-> varName)
+
+@Test("Output capture sets UUID and CustomOutputName")
+func outputCapture() throws {
+    let result = try compile("getBattery() -> level")
+    let acts = actions(from: result)
+    let p = params(of: acts[0])
+    #expect(p["CustomOutputName"] as? String == "level")
+    #expect(p["UUID"] as? String != nil)
+}
+
+@Test("Output capture can be referenced as ActionOutput")
+func outputCaptureReference() throws {
+    let result = try compile("""
+    getBattery() -> level
+    showResult(text: "\\(level)")
+    """)
+    let acts = actions(from: result)
+    let p = params(of: acts[1])
+    let text = p["Text"] as! [String: Any]
+    let value = text["Value"] as! [String: Any]
+    let attachments = value["attachmentsByRange"] as! [String: Any]
+    let attachment = attachments["{0, 1}"] as! [String: Any]
+    #expect(attachment["Type"] as? String == "ActionOutput")
+    #expect(attachment["OutputName"] as? String == "level")
+    #expect(attachment["OutputUUID"] as? String != nil)
+}
+
+// MARK: - Variable Declarations
+
+@Test("var declaration emits setvariable action")
+func varDeclaration() throws {
+    let result = try compile("var name = \"hello\"")
+    let acts = actions(from: result)
+    // String literal var: text action + setvariable
+    #expect(acts.count == 2)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.gettext")
+    #expect(identifier(of: acts[1]) == "is.workflow.actions.setvariable")
+    let p = params(of: acts[1])
+    #expect(p["WFVariableName"] as? String == "name")
+}
+
+@Test("var with variable reference emits direct setvariable")
+func varWithReference() throws {
+    let result = try compile("""
+    getBattery() -> level
+    var x = level
+    """)
+    let acts = actions(from: result)
+    // getBattery + setvariable (direct, no text action)
+    #expect(acts.count == 2)
+    #expect(identifier(of: acts[1]) == "is.workflow.actions.setvariable")
+    let p = params(of: acts[1])
+    #expect(p["WFVariableName"] as? String == "x")
+    // The WFInput should reference level via ActionOutput
+    let wfInput = p["WFInput"] as! [String: Any]
+    let inputValue = wfInput["Value"] as! [String: Any]
+    #expect(inputValue["Type"] as? String == "ActionOutput")
+}
+
+@Test("var with shortcutInput emits ExtensionInput in setvariable")
+func varWithShortcutInput() throws {
+    let result = try compile("var x = shortcutInput")
+    let acts = actions(from: result)
+    #expect(acts.count == 1)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.setvariable")
+    let p = params(of: acts[0])
+    let wfInput = p["WFInput"] as! [String: Any]
+    let inputValue = wfInput["Value"] as! [String: Any]
+    #expect(inputValue["Type"] as? String == "ExtensionInput")
+}
+
+@Test("var with dictionary emits dictionary action + setvariable")
+func varWithDictionary() throws {
+    let result = try compile("var d = { \"key\": \"value\" }")
+    let acts = actions(from: result)
+    #expect(acts.count == 2)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.dictionary")
+    #expect(identifier(of: acts[1]) == "is.workflow.actions.setvariable")
+}
+
+// MARK: - If/Else
+
+@Test("If statement emits conditional actions with grouping")
+func ifStatement() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level == "100" {
+        showResult(text: "full")
+    }
+    """)
+    let acts = actions(from: result)
+    // getBattery, conditional(start), showResult, conditional(end)
+    #expect(acts.count == 4)
+    #expect(identifier(of: acts[1]) == "is.workflow.actions.conditional")
+    #expect(identifier(of: acts[3]) == "is.workflow.actions.conditional")
+
+    // Start has WFControlFlowMode 0, end has 2
+    let startParams = params(of: acts[1])
+    let endParams = params(of: acts[3])
+    #expect(startParams["WFControlFlowMode"] as? Int == 0)
+    #expect(endParams["WFControlFlowMode"] as? Int == 2)
+
+    // Same GroupingIdentifier
+    let groupID = startParams["GroupingIdentifier"] as! String
+    #expect(endParams["GroupingIdentifier"] as? String == groupID)
+}
+
+@Test("If-else emits three conditional markers")
+func ifElseStatement() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level == "100" {
+        showResult(text: "full")
+    } else {
+        showResult(text: "not full")
+    }
+    """)
+    let acts = actions(from: result)
+    // getBattery, conditional(start), showResult, conditional(else), showResult, conditional(end)
+    #expect(acts.count == 6)
+    let elseParams = params(of: acts[3])
+    #expect(elseParams["WFControlFlowMode"] as? Int == 1)
+}
+
+@Test("If condition wires up correct WFCondition codes")
+func conditionCodes() throws {
+    let cases: [(String, Int)] = [
+        ("==", 4),
+        ("!=", 5),
+        (">", 2),
+        ("<", 3),
+        ("contains", 99),
+    ]
+    for (op, code) in cases {
+        let result = try compile("""
+        getBattery() -> level
+        if level \(op) "50" {
+            showResult(text: "ok")
+        }
+        """)
+        let acts = actions(from: result)
+        let startParams = params(of: acts[1])
+        #expect(startParams["WFCondition"] as? Int == code, "Expected code \(code) for operator \(op)")
+    }
+}
+
+// MARK: - Repeat Loop
+
+@Test("Repeat loop emits repeat.count actions")
+func repeatLoop() throws {
+    let result = try compile("""
+    repeat 3 {
+        getBattery()
+    }
+    """)
+    let acts = actions(from: result)
+    // repeat(start), getBattery, repeat(end)
+    #expect(acts.count == 3)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.repeat.count")
+    #expect(identifier(of: acts[2]) == "is.workflow.actions.repeat.count")
+    let startParams = params(of: acts[0])
+    #expect(startParams["WFControlFlowMode"] as? Int == 0)
+    #expect(startParams["WFRepeatCount"] as? Int == 3)
+    let endParams = params(of: acts[2])
+    #expect(endParams["WFControlFlowMode"] as? Int == 2)
+}
+
+// MARK: - For Each Loop
+
+@Test("For-each loop emits repeat.each actions")
+func forEachLoop() throws {
+    let result = try compile("""
+    getBattery() -> items
+    for item in items {
+        showResult(text: "\\(item)")
+    }
+    """)
+    let acts = actions(from: result)
+    // getBattery, repeat.each(start), showResult, repeat.each(end)
+    #expect(acts.count == 4)
+    #expect(identifier(of: acts[1]) == "is.workflow.actions.repeat.each")
+    #expect(identifier(of: acts[3]) == "is.workflow.actions.repeat.each")
+    let startParams = params(of: acts[1])
+    #expect(startParams["WFControlFlowMode"] as? Int == 0)
+}
+
+@Test("For-each loop variable resolves to Repeat Item")
+func forEachVariableResolvesToRepeatItem() throws {
+    let result = try compile("""
+    getBattery() -> items
+    for item in items {
+        showResult(text: "\\(item)")
+    }
+    """)
+    let acts = actions(from: result)
+    let showParams = params(of: acts[2])
+    let text = showParams["Text"] as! [String: Any]
+    let value = text["Value"] as! [String: Any]
+    let attachments = value["attachmentsByRange"] as! [String: Any]
+    let attachment = attachments["{0, 1}"] as! [String: Any]
+    #expect(attachment["VariableName"] as? String == "Repeat Item")
+}
+
+// MARK: - Menu
+
+@Test("Menu emits choosefrommenu actions")
+func menuActions() throws {
+    let result = try compile("""
+    menu "Pick" {
+        case "A":
+            getBattery()
+        case "B":
+            showResult(text: "b")
+    }
+    """)
+    let acts = actions(from: result)
+    // choosefrommenu(start), choosefrommenu(case A), getBattery, choosefrommenu(case B), showResult, choosefrommenu(end)
+    #expect(acts.count == 6)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.choosefrommenu")
+
+    let startParams = params(of: acts[0])
+    #expect(startParams["WFControlFlowMode"] as? Int == 0)
+    #expect(startParams["WFMenuPrompt"] as? String == "Pick")
+    let items = startParams["WFMenuItems"] as! [String]
+    #expect(items == ["A", "B"])
+
+    // Case markers have WFControlFlowMode 1
+    let caseAParams = params(of: acts[1])
+    #expect(caseAParams["WFControlFlowMode"] as? Int == 1)
+    #expect(caseAParams["WFMenuItemTitle"] as? String == "A")
+}
+
+// MARK: - Dictionary Literals
+
+@Test("Dictionary literal produces WFDictionaryFieldValue")
+func dictionaryCompilation() throws {
+    let result = try compile("var d = { \"name\": \"Alice\", \"age\": 30 }")
+    let acts = actions(from: result)
+    let dictParams = params(of: acts[0])
+    let wfItems = dictParams["WFItems"] as! [String: Any]
+    #expect(wfItems["WFSerializationType"] as? String == "WFDictionaryFieldValue")
+    let value = wfItems["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+    #expect(items.count == 2)
+}
+
+@Test("Dictionary number values use WFItemType 3")
+func dictionaryNumberType() throws {
+    let result = try compile("var d = { \"count\": 42 }")
+    let acts = actions(from: result)
+    let dictParams = params(of: acts[0])
+    let wfItems = dictParams["WFItems"] as! [String: Any]
+    let value = wfItems["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+    #expect(items[0]["WFItemType"] as? Int == 3)
+}
+
+@Test("Dictionary bool values use WFItemType 4")
+func dictionaryBoolType() throws {
+    let result = try compile("var d = { \"flag\": true }")
+    let acts = actions(from: result)
+    let dictParams = params(of: acts[0])
+    let wfItems = dictParams["WFItems"] as! [String: Any]
+    let value = wfItems["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+    #expect(items[0]["WFItemType"] as? Int == 4)
+}
+
+@Test("Nested dictionary uses WFItemType 1")
+func dictionaryNestedType() throws {
+    let result = try compile("var d = { \"outer\": { \"inner\": \"val\" } }")
+    let acts = actions(from: result)
+    let dictParams = params(of: acts[0])
+    let wfItems = dictParams["WFItems"] as! [String: Any]
+    let value = wfItems["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+    #expect(items[0]["WFItemType"] as? Int == 1)
+}
+
+// MARK: - Interpolated Strings
+
+@Test("Interpolated string produces correct attachmentsByRange")
+func interpolatedString() throws {
+    let result = try compile("""
+    getBattery() -> level
+    showResult(text: "Battery: \\(level)%")
+    """)
+    let acts = actions(from: result)
+    let p = params(of: acts[1])
+    let text = p["Text"] as! [String: Any]
+    let value = text["Value"] as! [String: Any]
+    let str = value["string"] as! String
+    // "Battery: " (9 chars) then \u{FFFC} then "%"
+    #expect(str == "Battery: \u{FFFC}%")
+    let attachments = value["attachmentsByRange"] as! [String: Any]
+    // Attachment at position 9
+    #expect(attachments["{9, 1}"] != nil)
+}
+
+@Test("Multiple interpolations in one string")
+func multipleInterpolations() throws {
+    let result = try compile("""
+    getBattery() -> a
+    getBattery() -> b
+    showResult(text: "\\(a) and \\(b)")
+    """)
+    let acts = actions(from: result)
+    let p = params(of: acts[2])
+    let text = p["Text"] as! [String: Any]
+    let value = text["Value"] as! [String: Any]
+    let attachments = value["attachmentsByRange"] as! [String: Any]
+    #expect(attachments.count == 2)
+}
+
+// MARK: - Metadata
+
+@Test("Metadata #name sets WFWorkflowName")
+func metadataName() throws {
+    let result = try compile("#name: My Shortcut")
+    #expect(result["WFWorkflowName"] as? String == "My Shortcut")
+}
+
+@Test("Metadata #color sets icon color")
+func metadataColor() throws {
+    let result = try compile("#color: red")
+    let icon = result["WFWorkflowIcon"] as! [String: Any]
+    #expect(icon["WFWorkflowIconStartColor"] as? Int == 4271458559)
+}
+
+@Test("Metadata #icon sets glyph number")
+func metadataIcon() throws {
+    let result = try compile("#icon: star")
+    let icon = result["WFWorkflowIcon"] as! [String: Any]
+    #expect(icon["WFWorkflowIconGlyphNumber"] as? Int == 59773)
+}
+
+@Test("Default shortcut name is 'Perspective Shortcut'")
+func defaultName() throws {
+    let result = try compile("getBattery()")
+    #expect(result["WFWorkflowName"] as? String == "Perspective Shortcut")
+}
+
+// MARK: - Comments
+
+@Test("Comments emit comment actions")
+func commentActions() throws {
+    let result = try compile("// This is a comment")
+    let acts = actions(from: result)
+    #expect(acts.count == 1)
+    #expect(identifier(of: acts[0]) == "is.workflow.actions.comment")
+    let p = params(of: acts[0])
+    #expect(p["WFCommentActionText"] as? String == "This is a comment")
+}
+
+// MARK: - Boolean Parameters
+
+@Test("Boolean parameter passes as plain value")
+func booleanParameter() throws {
+    let result = try compile("getFile(errorIfNotFound: true)")
+    let acts = actions(from: result)
+    let p = params(of: acts[0])
+    #expect(p["WFFileErrorIfNotFound"] as? Bool == true)
+}
+
+// MARK: - PlainString Parameters
+
+@Test("PlainString parameter passes as plain string")
+func plainStringParameter() throws {
+    let result = try compile("getFile(path: \"test.txt\")")
+    let acts = actions(from: result)
+    let p = params(of: acts[0])
+    #expect(p["WFGetFilePath"] as? String == "test.txt")
+}
+
+// MARK: - Undeclared Variables in Different Positions
+
+@Test("Undeclared variable in var assignment throws")
+func undeclaredInVarAssignment() throws {
+    #expect(throws: CompilerError.self) {
+        _ = try compile("var x = bogus")
+    }
+}
+
+@Test("Undeclared variable in if condition throws")
+func undeclaredInCondition() throws {
+    #expect(throws: CompilerError.self) {
+        _ = try compile("""
+        if bogus == "x" {
+            getBattery()
+        }
+        """)
+    }
+}
+
+// Note: for-each collection is not currently validated for undeclared variables.
+// This is a known gap — the compiler doesn't call validateExpression on the
+// collection expression in forEachLoop. Tracked for future fix.
+@Test("For-each with undeclared collection compiles (known gap)")
+func forEachUndeclaredCollectionCompiles() throws {
+    // This should ideally throw, but currently doesn't validate the collection.
+    let result = try compile("""
+    for item in bogus {
+        getBattery()
+    }
+    """)
+    let acts = actions(from: result)
+    #expect(acts.count == 3) // repeat.each(start), getBattery, repeat.each(end)
+}
+
+// MARK: - Plist Structure
+
+@Test("Compiled output has required top-level keys")
+func topLevelKeys() throws {
+    let result = try compile("getBattery()")
+    #expect(result["WFWorkflowMinimumClientVersionString"] as? String == "900")
+    #expect(result["WFWorkflowClientVersion"] as? String == "1200")
+    #expect(result["WFWorkflowActions"] != nil)
+    #expect(result["WFWorkflowIcon"] != nil)
+    #expect(result["WFWorkflowTypes"] != nil)
+    #expect(result["WFWorkflowInputContentItemClasses"] != nil)
+}
+
+} // end CompilerTests

--- a/Tests/CompilerTests.swift
+++ b/Tests/CompilerTests.swift
@@ -36,6 +36,18 @@ private func testRegistry() -> ActionRegistry {
                     "errorIfNotFound": ActionParameter(type: "boolean", required: false, key: "WFFileErrorIfNotFound")
                 ]
             ),
+            "downloadURL": ActionDefinition(
+                identifier: "is.workflow.actions.downloadurl",
+                description: "Download URL",
+                parameters: [
+                    "url": ActionParameter(type: "string", required: true, key: "WFURL"),
+                    "method": ActionParameter(type: "enum", required: false, key: "WFHTTPMethod"),
+                    "headers": ActionParameter(type: "dictionary", required: false, key: "WFHTTPHeaders"),
+                    "bodyType": ActionParameter(type: "enum", required: false, key: "WFHTTPBodyType"),
+                    "body": ActionParameter(type: "variable", required: false, key: "WFRequestVariable"),
+                    "formValues": ActionParameter(type: "formDictionary", required: false, key: "WFFormValues"),
+                ]
+            ),
         ],
         controlFlow: [:],
         iconColors: ["blue": 463140863, "red": 4271458559]
@@ -486,6 +498,83 @@ func dictionaryNestedType() throws {
     let value = wfItems["Value"] as! [String: Any]
     let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
     #expect(items[0]["WFItemType"] as? Int == 1)
+}
+
+// MARK: - Form Dictionary (formValues)
+
+@Test("formDictionary with variable reference produces WFItemType 5 (file)")
+func formDictionaryFileItem() throws {
+    let result = try compile("""
+    getBattery() -> myFile
+    downloadURL(url: "https://example.com/upload", method: "POST", bodyType: "Form", formValues: {"file": myFile})
+    """)
+    let acts = actions(from: result)
+    let uploadParams = params(of: acts[1])
+    let formValues = uploadParams["WFFormValues"] as! [String: Any]
+    let value = formValues["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+
+    #expect(items.count == 1)
+    #expect(items[0]["WFItemType"] as? Int == 5)
+
+    // Verify the value wrapping: WFTokenAttachmentParameterState > WFTextTokenAttachment
+    let wfValue = items[0]["WFValue"] as! [String: Any]
+    #expect(wfValue["WFSerializationType"] as? String == "WFTokenAttachmentParameterState")
+    let innerValue = wfValue["Value"] as! [String: Any]
+    #expect(innerValue["WFSerializationType"] as? String == "WFTextTokenAttachment")
+}
+
+@Test("formDictionary with string value produces WFItemType 0 (text)")
+func formDictionaryTextItem() throws {
+    let result = try compile("""
+    downloadURL(url: "https://example.com/upload", method: "POST", bodyType: "Form", formValues: {"name": "test.txt"})
+    """)
+    let acts = actions(from: result)
+    let uploadParams = params(of: acts[0])
+    let formValues = uploadParams["WFFormValues"] as! [String: Any]
+    let value = formValues["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+
+    #expect(items.count == 1)
+    #expect(items[0]["WFItemType"] as? Int == 0)
+}
+
+@Test("formDictionary with mixed file and text entries")
+func formDictionaryMixed() throws {
+    let result = try compile("""
+    getBattery() -> myFile
+    downloadURL(url: "https://example.com/upload", method: "POST", bodyType: "Form", formValues: {"file": myFile, "description": "a test file"})
+    """)
+    let acts = actions(from: result)
+    let uploadParams = params(of: acts[1])
+    let formValues = uploadParams["WFFormValues"] as! [String: Any]
+    let value = formValues["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+
+    #expect(items.count == 2)
+    // First entry: variable → file (5)
+    #expect(items[0]["WFItemType"] as? Int == 5)
+    // Second entry: string → text (0)
+    #expect(items[1]["WFItemType"] as? Int == 0)
+}
+
+@Test("formDictionary with shortcutInput produces ExtensionInput file item")
+func formDictionaryShortcutInput() throws {
+    let result = try compile("""
+    downloadURL(url: "https://example.com/upload", method: "POST", bodyType: "Form", formValues: {"file": shortcutInput})
+    """)
+    let acts = actions(from: result)
+    let uploadParams = params(of: acts[0])
+    let formValues = uploadParams["WFFormValues"] as! [String: Any]
+    let value = formValues["Value"] as! [String: Any]
+    let items = value["WFDictionaryFieldValueItems"] as! [[String: Any]]
+
+    #expect(items[0]["WFItemType"] as? Int == 5)
+
+    let wfValue = items[0]["WFValue"] as! [String: Any]
+    let innerValue = wfValue["Value"] as! [String: Any]
+    let attachment = innerValue["Value"] as! [String: Any]
+    #expect(attachment["Type"] as? String == "ExtensionInput")
 }
 
 // MARK: - Interpolated Strings

--- a/Tests/CompilerTests.swift
+++ b/Tests/CompilerTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import perspective_cuts
+
+/// Minimal registry with just the actions needed for tests.
+private func testRegistry() -> ActionRegistry {
+    ActionRegistry(
+        actions: [
+            "getBattery": ActionDefinition(
+                identifier: "is.workflow.actions.getbatterylevel",
+                description: "Get the current battery level",
+                parameters: [:]
+            ),
+            "showResult": ActionDefinition(
+                identifier: "is.workflow.actions.showresult",
+                description: "Show the result of the shortcut",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "Text")
+                ]
+            ),
+        ],
+        controlFlow: [:],
+        iconColors: [:]
+    )
+}
+
+@Test("Declared variable references compile successfully")
+func declaredVariableCompiles() throws {
+    let source = """
+    getBattery() -> level
+    showResult(text: "\\(level)")
+    """
+    let tokens = try Lexer(source: source).tokenize()
+    let nodes = try Parser(tokens: tokens).parse()
+    let result = try Compiler(registry: testRegistry()).compile(nodes: nodes)
+
+    let actions = result["WFWorkflowActions"] as! [[String: Any]]
+    #expect(actions.count == 2)
+}
+
+@Test("Undeclared variable reference produces compile error")
+func undeclaredVariableThrows() throws {
+    let source = """
+    showResult(text: "\\(bogusVar)")
+    """
+    let tokens = try Lexer(source: source).tokenize()
+    let nodes = try Parser(tokens: tokens).parse()
+
+    #expect(throws: CompilerError.self) {
+        _ = try Compiler(registry: testRegistry()).compile(nodes: nodes)
+    }
+}

--- a/Tests/CompilerTests.swift
+++ b/Tests/CompilerTests.swift
@@ -265,6 +265,96 @@ func conditionCodes() throws {
     }
 }
 
+@Test("Numeric comparisons (> <) use WFNumberContentItem coercion")
+func numericCoercion() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level > "50" {
+        showResult(text: "high")
+    }
+    """)
+    let acts = actions(from: result)
+    let condParams = params(of: acts[1])
+
+    // LHS should be coerced to WFNumberContentItem, not WFStringContentItem
+    let input = condParams["WFInput"] as! [String: Any]
+    let variable = input["Variable"] as! [String: Any]
+    let value = variable["Value"] as! [String: Any]
+    let aggr = value["Aggrandizements"] as! [[String: Any]]
+    #expect(aggr[0]["CoercionItemClass"] as? String == "WFNumberContentItem")
+}
+
+@Test("String comparisons (== != contains) use WFStringContentItem coercion")
+func stringCoercion() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level == "50" {
+        showResult(text: "exact")
+    }
+    """)
+    let acts = actions(from: result)
+    let condParams = params(of: acts[1])
+
+    let input = condParams["WFInput"] as! [String: Any]
+    let variable = input["Variable"] as! [String: Any]
+    let value = variable["Value"] as! [String: Any]
+    let aggr = value["Aggrandizements"] as! [[String: Any]]
+    #expect(aggr[0]["CoercionItemClass"] as? String == "WFStringContentItem")
+}
+
+@Test("Numeric comparisons use WFNumberValue instead of WFConditionalActionString")
+func numericConditionValue() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level > "0" {
+        showResult(text: "positive")
+    }
+    """)
+    let acts = actions(from: result)
+    let condParams = params(of: acts[1])
+
+    #expect(condParams["WFNumberValue"] as? String == "0")
+    #expect(condParams["WFConditionalActionString"] == nil)
+}
+
+@Test("String comparisons use WFConditionalActionString, not WFNumberValue")
+func stringConditionValue() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level == "active" {
+        showResult(text: "yes")
+    }
+    """)
+    let acts = actions(from: result)
+    let condParams = params(of: acts[1])
+
+    #expect(condParams["WFConditionalActionString"] as? String == "active")
+    #expect(condParams["WFNumberValue"] == nil)
+}
+
+@Test("Less-than uses WFNumberContentItem coercion and WFNumberValue")
+func lessThanCoercion() throws {
+    let result = try compile("""
+    getBattery() -> level
+    if level < "10" {
+        showResult(text: "low")
+    }
+    """)
+    let acts = actions(from: result)
+    let condParams = params(of: acts[1])
+
+    // Coercion
+    let input = condParams["WFInput"] as! [String: Any]
+    let variable = input["Variable"] as! [String: Any]
+    let value = variable["Value"] as! [String: Any]
+    let aggr = value["Aggrandizements"] as! [[String: Any]]
+    #expect(aggr[0]["CoercionItemClass"] as? String == "WFNumberContentItem")
+
+    // Value key
+    #expect(condParams["WFNumberValue"] as? String == "10")
+    #expect(condParams["WFConditionalActionString"] == nil)
+}
+
 // MARK: - Repeat Loop
 
 @Test("Repeat loop emits repeat.count actions")
@@ -459,6 +549,26 @@ func metadataIcon() throws {
 func defaultName() throws {
     let result = try compile("getBattery()")
     #expect(result["WFWorkflowName"] as? String == "Perspective Shortcut")
+}
+
+@Test("Metadata #noInputBehavior: doNothing sets WFWorkflowNoInputBehavior")
+func noInputBehaviorDoNothing() throws {
+    let result = try compile("#noInputBehavior: doNothing")
+    let behavior = result["WFWorkflowNoInputBehavior"] as? [String: Any]
+    #expect(behavior?["Name"] as? String == "WFWorkflowNoInputBehaviorDoNothing")
+}
+
+@Test("Metadata #noInputBehavior: askForInput sets WFWorkflowNoInputBehavior")
+func noInputBehaviorAskForInput() throws {
+    let result = try compile("#noInputBehavior: askForInput")
+    let behavior = result["WFWorkflowNoInputBehavior"] as? [String: Any]
+    #expect(behavior?["Name"] as? String == "WFWorkflowNoInputBehaviorAskForInput")
+}
+
+@Test("No #noInputBehavior omits WFWorkflowNoInputBehavior key")
+func noInputBehaviorDefault() throws {
+    let result = try compile("getBattery()")
+    #expect(result["WFWorkflowNoInputBehavior"] == nil)
 }
 
 // MARK: - Comments

--- a/Tests/CompilerTests.swift
+++ b/Tests/CompilerTests.swift
@@ -48,6 +48,20 @@ private func testRegistry() -> ActionRegistry {
                     "formValues": ActionParameter(type: "formDictionary", required: false, key: "WFFormValues"),
                 ]
             ),
+            "getDictionary": ActionDefinition(
+                identifier: "is.workflow.actions.detect.dictionary",
+                description: "Get dictionary from input",
+                parameters: [
+                    "input": ActionParameter(type: "variable", required: true, key: "WFInput", coerce: "string")
+                ]
+            ),
+            "noCoerceSink": ActionDefinition(
+                identifier: "test.no.coerce.sink",
+                description: "Test action whose variable parameter has no coerce hint",
+                parameters: [
+                    "input": ActionParameter(type: "variable", required: true, key: "WFInput")
+                ]
+            ),
         ],
         controlFlow: [:],
         iconColors: ["blue": 463140863, "red": 4271458559]
@@ -294,6 +308,42 @@ func numericCoercion() throws {
     let value = variable["Value"] as! [String: Any]
     let aggr = value["Aggrandizements"] as! [[String: Any]]
     #expect(aggr[0]["CoercionItemClass"] as? String == "WFNumberContentItem")
+}
+
+@Test("Variable parameter with coerce: string injects WFStringContentItem aggrandizement")
+func variableParamCoercesToString() throws {
+    let result = try compile("""
+    downloadURL(url: "https://example.com") -> raw
+    getDictionary(input: raw) -> dict
+    """)
+    let acts = actions(from: result)
+    // [0] downloadURL, [1] getDictionary
+    let getDictParams = params(of: acts[1])
+    #expect(identifier(of: acts[1]) == "is.workflow.actions.detect.dictionary")
+
+    let input = getDictParams["WFInput"] as! [String: Any]
+    #expect(input["WFSerializationType"] as? String == "WFTextTokenAttachment")
+    let value = input["Value"] as! [String: Any]
+    // The value should still point at the downloadURL action output
+    #expect(value["Type"] as? String == "ActionOutput")
+    // …and now carry the string-coercion aggrandizement
+    let aggr = value["Aggrandizements"] as! [[String: Any]]
+    #expect(aggr.count == 1)
+    #expect(aggr[0]["CoercionItemClass"] as? String == "WFStringContentItem")
+    #expect(aggr[0]["Type"] as? String == "WFCoercionVariableAggrandizement")
+}
+
+@Test("Variable parameter without coerce omits Aggrandizements")
+func variableParamWithoutCoerceHasNoAggrandizements() throws {
+    let result = try compile("""
+    downloadURL(url: "https://example.com") -> raw
+    noCoerceSink(input: raw)
+    """)
+    let acts = actions(from: result)
+    let sinkParams = params(of: acts[1])
+    let input = sinkParams["WFInput"] as! [String: Any]
+    let value = input["Value"] as! [String: Any]
+    #expect(value["Aggrandizements"] == nil)
 }
 
 @Test("String comparisons (== != contains) use WFStringContentItem coercion")

--- a/Tests/LexerTests.swift
+++ b/Tests/LexerTests.swift
@@ -1,0 +1,159 @@
+import Testing
+@testable import perspective_cuts
+
+@Suite("Lexer")
+struct LexerTests {
+
+// MARK: - Keywords
+
+@Test("Lexer tokenizes keywords")
+func keywords() throws {
+    let source = "import let var if else repeat for in menu case func return contains"
+    let tokens = try Lexer(source: source).tokenize()
+    let kinds = tokens.map(\.kind)
+    #expect(kinds == [
+        .importKeyword, .letKeyword, .varKeyword, .ifKeyword, .elseKeyword,
+        .repeatKeyword, .forKeyword, .inKeyword, .menuKeyword, .caseKeyword,
+        .funcKeyword, .returnKeyword, .containsKeyword, .eof
+    ])
+}
+
+// MARK: - Identifiers
+
+@Test("Lexer tokenizes identifiers")
+func identifiers() throws {
+    let tokens = try Lexer(source: "foo bar_baz _x").tokenize()
+    let kinds = tokens.map(\.kind)
+    #expect(kinds == [.identifier("foo"), .identifier("bar_baz"), .identifier("_x"), .eof])
+}
+
+@Test("Lexer allows hyphens in identifiers")
+func hyphenatedIdentifiers() throws {
+    let tokens = try Lexer(source: "my-action").tokenize()
+    #expect(tokens[0].kind == .identifier("my-action"))
+}
+
+// MARK: - Literals
+
+@Test("Lexer tokenizes string literals")
+func stringLiterals() throws {
+    let tokens = try Lexer(source: "\"hello world\"").tokenize()
+    #expect(tokens[0].kind == .stringLiteral("hello world"))
+}
+
+@Test("Lexer handles escape sequences in strings")
+func escapeSequences() throws {
+    let tokens = try Lexer(source: "\"line1\\nline2\\ttab\\\\slash\\\"quote\"").tokenize()
+    #expect(tokens[0].kind == .stringLiteral("line1\nline2\ttab\\slash\"quote"))
+}
+
+@Test("Lexer preserves interpolation markers in strings")
+func stringInterpolation() throws {
+    let tokens = try Lexer(source: "\"hello \\(name)\"").tokenize()
+    #expect(tokens[0].kind == .stringLiteral("hello \\(name)"))
+}
+
+@Test("Lexer tokenizes integer numbers")
+func integerNumbers() throws {
+    let tokens = try Lexer(source: "42").tokenize()
+    #expect(tokens[0].kind == .numberLiteral(42.0))
+}
+
+@Test("Lexer tokenizes decimal numbers")
+func decimalNumbers() throws {
+    let tokens = try Lexer(source: "3.14").tokenize()
+    #expect(tokens[0].kind == .numberLiteral(3.14))
+}
+
+@Test("Lexer tokenizes booleans")
+func booleans() throws {
+    let tokens = try Lexer(source: "true false").tokenize()
+    #expect(tokens[0].kind == .boolLiteral(true))
+    #expect(tokens[1].kind == .boolLiteral(false))
+}
+
+// MARK: - Comments
+
+@Test("Lexer tokenizes line comments")
+func lineComments() throws {
+    let tokens = try Lexer(source: "// this is a comment").tokenize()
+    #expect(tokens[0].kind == .comment("this is a comment"))
+}
+
+@Test("Lexer tokenizes block comments")
+func blockComments() throws {
+    let tokens = try Lexer(source: "/* block comment */").tokenize()
+    #expect(tokens[0].kind == .comment("block comment"))
+}
+
+@Test("Lexer handles multiline block comments")
+func multilineBlockComments() throws {
+    let tokens = try Lexer(source: "/* line1\nline2 */").tokenize()
+    #expect(tokens[0].kind == .comment("line1\nline2"))
+}
+
+// MARK: - Operators and Punctuation
+
+@Test("Lexer tokenizes operators")
+func operators() throws {
+    let tokens = try Lexer(source: "-> == != = > <").tokenize()
+    let kinds = tokens.map(\.kind)
+    #expect(kinds == [.arrow, .doubleEquals, .notEquals, .equals, .greaterThan, .lessThan, .eof])
+}
+
+@Test("Lexer tokenizes punctuation")
+func punctuation() throws {
+    let tokens = try Lexer(source: "( ) { } [ ] , : # .").tokenize()
+    let kinds = tokens.map(\.kind)
+    #expect(kinds == [
+        .leftParen, .rightParen, .leftBrace, .rightBrace,
+        .leftBracket, .rightBracket, .comma, .colon, .hash, .dot, .eof
+    ])
+}
+
+// MARK: - Newlines
+
+@Test("Lexer emits newline tokens")
+func newlines() throws {
+    let tokens = try Lexer(source: "foo\nbar").tokenize()
+    let kinds = tokens.map(\.kind)
+    #expect(kinds == [.identifier("foo"), .newline, .identifier("bar"), .eof])
+}
+
+// MARK: - Source Locations
+
+@Test("Lexer tracks line and column numbers")
+func sourceLocations() throws {
+    let tokens = try Lexer(source: "foo\nbar baz").tokenize()
+    #expect(tokens[0].location.line == 1)
+    #expect(tokens[0].location.column == 1)
+    // tokens[1] is newline
+    #expect(tokens[2].location.line == 2)
+    #expect(tokens[2].location.column == 1)
+    #expect(tokens[3].location.line == 2)
+    #expect(tokens[3].location.column == 5)
+}
+
+// MARK: - Error Cases
+
+@Test("Lexer rejects unexpected characters")
+func unexpectedCharacter() throws {
+    #expect(throws: LexerError.self) {
+        _ = try Lexer(source: "~").tokenize()
+    }
+}
+
+// MARK: - Full Statement
+
+@Test("Lexer tokenizes a complete action call")
+func fullActionCall() throws {
+    let tokens = try Lexer(source: "showResult(text: \"hello\") -> output").tokenize()
+    let kinds = tokens.map(\.kind)
+    #expect(kinds == [
+        .identifier("showResult"), .leftParen,
+        .identifier("text"), .colon, .stringLiteral("hello"),
+        .rightParen, .arrow, .identifier("output"), .eof
+    ])
+}
+
+} // end LexerTests

--- a/Tests/LockAnalyzerTests.swift
+++ b/Tests/LockAnalyzerTests.swift
@@ -1,0 +1,247 @@
+import Testing
+@testable import perspective_cuts
+
+/// Stub that returns configurable policies per identifier.
+struct StubPolicyProvider: AuthenticationPolicyProvider {
+    let policies: [String: String]
+
+    func getAuthenticationPolicy(identifier: String) -> String? {
+        policies[identifier]
+    }
+}
+
+@Suite("LockAnalyzer")
+struct LockAnalyzerTests {
+
+    private let registry = ActionRegistry(
+        actions: [
+            "getClipboard": ActionDefinition(
+                identifier: "is.workflow.actions.getclipboard",
+                description: "Get clipboard",
+                parameters: [:]
+            ),
+            "openApp": ActionDefinition(
+                identifier: "is.workflow.actions.openapp",
+                description: "Open app",
+                parameters: [
+                    "app": ActionParameter(type: "string", required: true, key: "WFAppIdentifier")
+                ]
+            ),
+            "text": ActionDefinition(
+                identifier: "is.workflow.actions.gettext",
+                description: "Get text",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "WFTextActionText")
+                ]
+            ),
+        ],
+        controlFlow: [:],
+        iconColors: [:]
+    )
+
+    private let provider = StubPolicyProvider(policies: [
+        "is.workflow.actions.getclipboard": "requiresAuthenticationOnOriginAndRemote",
+        "is.workflow.actions.openapp": "requiresAuthenticationOnOriginAndRemote",
+        "is.workflow.actions.gettext": "none",
+    ])
+
+    private func loc(_ line: Int) -> perspective_cuts.SourceLocation {
+        perspective_cuts.SourceLocation(line: line, column: 1)
+    }
+
+    @Test("No diagnostics for safe actions")
+    func safeActions() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "text", arguments: [(label: "text", value: .stringLiteral("hello"))], output: nil, location: loc(1))
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.isEmpty)
+    }
+
+    @Test("Detects unlock-requiring action at top level")
+    func topLevelUnlock() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "getClipboard", arguments: [], output: "clip", location: loc(3))
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].actionName == "getClipboard")
+        #expect(diags[0].branchContext == nil)
+        #expect(diags[0].description.contains("always reachable"))
+    }
+
+    @Test("Reports branch context for if-then")
+    func ifThenBranch() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("mode"), right: .stringLiteral("copy")),
+                thenBody: [
+                    .actionCall(name: "getClipboard", arguments: [], output: "clip", location: loc(5))
+                ],
+                elseBody: nil,
+                location: loc(4)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "when mode == \"copy\"")
+    }
+
+    @Test("Reports branch context for if-else")
+    func ifElseBranch() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("x"), right: .numberLiteral(1)),
+                thenBody: [
+                    .actionCall(name: "text", arguments: [(label: "text", value: .stringLiteral("safe"))], output: nil, location: loc(3))
+                ],
+                elseBody: [
+                    .actionCall(name: "openApp", arguments: [(label: "app", value: .stringLiteral("Safari"))], output: nil, location: loc(5))
+                ],
+                location: loc(2)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].actionName == "openApp")
+        #expect(diags[0].branchContext == "when not (x == 1)")
+    }
+
+    @Test("Reports branch context for nested ifs")
+    func nestedIfs() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("a"), right: .stringLiteral("1")),
+                thenBody: [
+                    .ifStatement(
+                        condition: .equals(left: .variableReference("b"), right: .stringLiteral("2")),
+                        thenBody: [
+                            .actionCall(name: "getClipboard", arguments: [], output: nil, location: loc(7))
+                        ],
+                        elseBody: nil,
+                        location: loc(5)
+                    )
+                ],
+                elseBody: nil,
+                location: loc(3)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "when a == \"1\", when b == \"2\"")
+    }
+
+    @Test("Reports menu case context")
+    func menuCase() {
+        let nodes: [ASTNode] = [
+            .menu(
+                title: "Pick one",
+                cases: [
+                    (label: "Safe", body: [
+                        .actionCall(name: "text", arguments: [(label: "text", value: .stringLiteral("ok"))], output: nil, location: loc(4))
+                    ]),
+                    (label: "Risky", body: [
+                        .actionCall(name: "openApp", arguments: [(label: "app", value: .stringLiteral("Safari"))], output: nil, location: loc(6))
+                    ]),
+                ],
+                location: loc(2)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "in menu \"Pick one\" case \"Risky\"")
+    }
+
+    @Test("Actions inside for-each inherit parent context")
+    func forEachLoop() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("x"), right: .stringLiteral("go")),
+                thenBody: [
+                    .forEachLoop(
+                        itemName: "item",
+                        collection: .variableReference("items"),
+                        body: [
+                            .actionCall(name: "getClipboard", arguments: [], output: nil, location: loc(6))
+                        ],
+                        location: loc(4)
+                    )
+                ],
+                elseBody: nil,
+                location: loc(2)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "when x == \"go\"")
+    }
+
+    @Test("Actions inside repeat loop inherit parent context")
+    func repeatLoop() {
+        let nodes: [ASTNode] = [
+            .repeatLoop(
+                count: .numberLiteral(3),
+                body: [
+                    .actionCall(name: "openApp", arguments: [(label: "app", value: .stringLiteral("Safari"))], output: nil, location: loc(3))
+                ],
+                location: loc(1)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == nil)
+    }
+
+    @Test("Dotted 3rd-party identifiers are looked up directly")
+    func thirdPartyAction() {
+        let thirdPartyProvider = StubPolicyProvider(policies: [
+            "com.example.app.SomeIntent": "requiresAuthenticationOnOrigin",
+        ])
+        let nodes: [ASTNode] = [
+            .actionCall(name: "com.example.app.SomeIntent", arguments: [], output: nil, location: loc(1))
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: thirdPartyProvider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].identifier == "com.example.app.SomeIntent")
+        #expect(diags[0].policy == "requiresAuthenticationOnOrigin")
+    }
+
+    @Test("Unknown actions produce no diagnostics")
+    func unknownAction() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "madeUpAction", arguments: [], output: nil, location: loc(1))
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.isEmpty)
+    }
+
+    @Test("Multiple diagnostics across branches")
+    func multipleDiagnostics() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "getClipboard", arguments: [], output: nil, location: loc(1)),
+            .ifStatement(
+                condition: .equals(left: .variableReference("x"), right: .stringLiteral("y")),
+                thenBody: [
+                    .actionCall(name: "openApp", arguments: [(label: "app", value: .stringLiteral("Safari"))], output: nil, location: loc(4))
+                ],
+                elseBody: nil,
+                location: loc(3)
+            )
+        ]
+        let analyzer = LockAnalyzer(registry: registry, policyProvider: provider)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 2)
+        #expect(diags[0].branchContext == nil) // top-level getClipboard
+        #expect(diags[1].branchContext == "when x == \"y\"") // conditional openApp
+    }
+}

--- a/Tests/ParserTests.swift
+++ b/Tests/ParserTests.swift
@@ -1,0 +1,429 @@
+import Testing
+@testable import perspective_cuts
+
+@Suite("Parser")
+struct ParserTests {
+
+private func parse(_ source: String) throws -> [ASTNode] {
+    let tokens = try Lexer(source: source).tokenize()
+    return try Parser(tokens: tokens).parse()
+}
+
+// MARK: - Import
+
+@Test("Parser parses import statement")
+func importStatement() throws {
+    let nodes = try parse("import Shortcuts")
+    guard case .importStatement(let module, _) = nodes[0] else {
+        Issue.record("Expected importStatement")
+        return
+    }
+    #expect(module == "Shortcuts")
+}
+
+// MARK: - Metadata
+
+@Test("Parser parses metadata directives")
+func metadata() throws {
+    let nodes = try parse("#name: My Shortcut")
+    guard case .metadata(let key, let value, _) = nodes[0] else {
+        Issue.record("Expected metadata")
+        return
+    }
+    #expect(key == "name")
+    #expect(value == "My Shortcut")
+}
+
+@Test("Parser parses multiple metadata")
+func multipleMetadata() throws {
+    let nodes = try parse("#color: blue\n#icon: gear\n#name: Test")
+    #expect(nodes.count == 3)
+    for node in nodes {
+        guard case .metadata = node else {
+            Issue.record("Expected metadata node")
+            return
+        }
+    }
+}
+
+// MARK: - Comments
+
+@Test("Parser parses comments")
+func comments() throws {
+    let nodes = try parse("// hello world")
+    guard case .comment(let text, _) = nodes[0] else {
+        Issue.record("Expected comment")
+        return
+    }
+    #expect(text == "hello world")
+}
+
+// MARK: - Variable Declarations
+
+@Test("Parser parses var declaration with string")
+func varDeclarationString() throws {
+    let nodes = try parse("var name = \"hello\"")
+    guard case .variableDeclaration(let name, let value, let isConstant, _) = nodes[0] else {
+        Issue.record("Expected variableDeclaration")
+        return
+    }
+    #expect(name == "name")
+    #expect(isConstant == false)
+    guard case .stringLiteral(let s) = value else {
+        Issue.record("Expected string literal value")
+        return
+    }
+    #expect(s == "hello")
+}
+
+@Test("Parser parses let declaration with number")
+func letDeclarationNumber() throws {
+    let nodes = try parse("let count = 42")
+    guard case .variableDeclaration(let name, let value, let isConstant, _) = nodes[0] else {
+        Issue.record("Expected variableDeclaration")
+        return
+    }
+    #expect(name == "count")
+    #expect(isConstant == true)
+    guard case .numberLiteral(let n) = value else {
+        Issue.record("Expected number literal value")
+        return
+    }
+    #expect(n == 42.0)
+}
+
+@Test("Parser parses var with variable reference")
+func varWithReference() throws {
+    let nodes = try parse("var x = other")
+    guard case .variableDeclaration(_, let value, _, _) = nodes[0] else {
+        Issue.record("Expected variableDeclaration")
+        return
+    }
+    guard case .variableReference(let ref) = value else {
+        Issue.record("Expected variable reference")
+        return
+    }
+    #expect(ref == "other")
+}
+
+@Test("Parser parses var with interpolated string")
+func varWithInterpolation() throws {
+    let nodes = try parse("var msg = \"hello \\(name)\"")
+    guard case .variableDeclaration(_, let value, _, _) = nodes[0] else {
+        Issue.record("Expected variableDeclaration")
+        return
+    }
+    guard case .interpolatedString(let parts) = value else {
+        Issue.record("Expected interpolated string")
+        return
+    }
+    #expect(parts.count == 2)
+}
+
+// MARK: - Action Calls
+
+@Test("Parser parses action call with no args")
+func actionCallNoArgs() throws {
+    let nodes = try parse("getBattery()")
+    guard case .actionCall(let name, let args, let output, _) = nodes[0] else {
+        Issue.record("Expected actionCall")
+        return
+    }
+    #expect(name == "getBattery")
+    #expect(args.isEmpty)
+    #expect(output == nil)
+}
+
+@Test("Parser parses action call with labeled arg")
+func actionCallWithArg() throws {
+    let nodes = try parse("showResult(text: \"hello\")")
+    guard case .actionCall(let name, let args, _, _) = nodes[0] else {
+        Issue.record("Expected actionCall")
+        return
+    }
+    #expect(name == "showResult")
+    #expect(args.count == 1)
+    #expect(args[0].label == "text")
+    guard case .stringLiteral(let s) = args[0].value else {
+        Issue.record("Expected string literal arg")
+        return
+    }
+    #expect(s == "hello")
+}
+
+@Test("Parser parses action call with output capture")
+func actionCallWithOutput() throws {
+    let nodes = try parse("getBattery() -> level")
+    guard case .actionCall(_, _, let output, _) = nodes[0] else {
+        Issue.record("Expected actionCall")
+        return
+    }
+    #expect(output == "level")
+}
+
+@Test("Parser parses action call with multiple args")
+func actionCallMultipleArgs() throws {
+    let nodes = try parse("doThing(a: \"x\", b: 42, c: true)")
+    guard case .actionCall(_, let args, _, _) = nodes[0] else {
+        Issue.record("Expected actionCall")
+        return
+    }
+    #expect(args.count == 3)
+    #expect(args[0].label == "a")
+    #expect(args[1].label == "b")
+    #expect(args[2].label == "c")
+}
+
+@Test("Parser parses dotted action names")
+func dottedActionName() throws {
+    let nodes = try parse("com.example.app.DoThing()")
+    guard case .actionCall(let name, _, _, _) = nodes[0] else {
+        Issue.record("Expected actionCall")
+        return
+    }
+    #expect(name == "com.example.app.DoThing")
+}
+
+// MARK: - If Statements
+
+@Test("Parser parses if statement")
+func ifStatement() throws {
+    let nodes = try parse("""
+    if x == "yes" {
+        getBattery()
+    }
+    """)
+    guard case .ifStatement(let condition, let thenBody, let elseBody, _) = nodes[0] else {
+        Issue.record("Expected ifStatement")
+        return
+    }
+    guard case .equals = condition else {
+        Issue.record("Expected equals condition")
+        return
+    }
+    #expect(thenBody.count == 1)
+    #expect(elseBody == nil)
+}
+
+@Test("Parser parses if-else statement")
+func ifElseStatement() throws {
+    let nodes = try parse("""
+    if x == "yes" {
+        getBattery()
+    } else {
+        showResult(text: "no")
+    }
+    """)
+    guard case .ifStatement(_, let thenBody, let elseBody, _) = nodes[0] else {
+        Issue.record("Expected ifStatement")
+        return
+    }
+    #expect(thenBody.count == 1)
+    #expect(elseBody?.count == 1)
+}
+
+@Test("Parser parses all comparison operators")
+func comparisonOperators() throws {
+    let cases: [(String, String)] = [
+        ("x == \"a\"", "equals"),
+        ("x != \"a\"", "notEquals"),
+        ("x > 5", "greaterThan"),
+        ("x < 5", "lessThan"),
+        ("x contains \"a\"", "contains"),
+    ]
+    for (condSource, expectedOp) in cases {
+        let nodes = try parse("if \(condSource) { getBattery() }")
+        guard case .ifStatement(let condition, _, _, _) = nodes[0] else {
+            Issue.record("Expected ifStatement for \(expectedOp)")
+            continue
+        }
+        switch (condition, expectedOp) {
+        case (.equals, "equals"),
+             (.notEquals, "notEquals"),
+             (.greaterThan, "greaterThan"),
+             (.lessThan, "lessThan"),
+             (.contains, "contains"):
+            break // matched
+        default:
+            Issue.record("Expected \(expectedOp) condition, got \(condition)")
+        }
+    }
+}
+
+// MARK: - Repeat Loop
+
+@Test("Parser parses repeat loop")
+func repeatLoop() throws {
+    let nodes = try parse("""
+    repeat 5 {
+        getBattery()
+    }
+    """)
+    guard case .repeatLoop(let count, let body, _) = nodes[0] else {
+        Issue.record("Expected repeatLoop")
+        return
+    }
+    guard case .numberLiteral(let n) = count else {
+        Issue.record("Expected number literal count")
+        return
+    }
+    #expect(n == 5.0)
+    #expect(body.count == 1)
+}
+
+// MARK: - For Each Loop
+
+@Test("Parser parses for-each loop")
+func forEachLoop() throws {
+    let nodes = try parse("""
+    for item in items {
+        showResult(text: "hi")
+    }
+    """)
+    guard case .forEachLoop(let itemName, let collection, let body, _) = nodes[0] else {
+        Issue.record("Expected forEachLoop")
+        return
+    }
+    #expect(itemName == "item")
+    guard case .variableReference(let collName) = collection else {
+        Issue.record("Expected variable reference collection")
+        return
+    }
+    #expect(collName == "items")
+    #expect(body.count == 1)
+}
+
+// MARK: - Menu
+
+@Test("Parser parses menu with cases")
+func menu() throws {
+    let nodes = try parse("""
+    menu "Pick one" {
+        case "Option A":
+            getBattery()
+        case "Option B":
+            showResult(text: "b")
+    }
+    """)
+    guard case .menu(let title, let cases, _) = nodes[0] else {
+        Issue.record("Expected menu")
+        return
+    }
+    #expect(title == "Pick one")
+    #expect(cases.count == 2)
+    #expect(cases[0].label == "Option A")
+    #expect(cases[1].label == "Option B")
+    #expect(cases[0].body.count == 1)
+    #expect(cases[1].body.count == 1)
+}
+
+// MARK: - Dictionary Literals
+
+@Test("Parser parses dictionary literal")
+func dictionaryLiteral() throws {
+    let nodes = try parse("var d = { \"key\": \"value\", count: 42 }")
+    guard case .variableDeclaration(_, let value, _, _) = nodes[0] else {
+        Issue.record("Expected variableDeclaration")
+        return
+    }
+    guard case .dictionaryLiteral(let entries) = value else {
+        Issue.record("Expected dictionary literal")
+        return
+    }
+    #expect(entries.count == 2)
+}
+
+@Test("Parser parses nested dictionary")
+func nestedDictionary() throws {
+    let nodes = try parse("var d = { outer: { inner: \"val\" } }")
+    guard case .variableDeclaration(_, let value, _, _) = nodes[0] else {
+        Issue.record("Expected variableDeclaration")
+        return
+    }
+    guard case .dictionaryLiteral(let entries) = value else {
+        Issue.record("Expected dictionary literal")
+        return
+    }
+    #expect(entries.count == 1)
+    guard case .dictionaryLiteral(let inner) = entries[0].value else {
+        Issue.record("Expected nested dictionary")
+        return
+    }
+    #expect(inner.count == 1)
+}
+
+// MARK: - Function Declaration
+
+@Test("Parser parses function declaration")
+func functionDeclaration() throws {
+    let nodes = try parse("""
+    func doStuff() {
+        getBattery()
+    }
+    """)
+    guard case .functionDeclaration(let name, let body, _) = nodes[0] else {
+        Issue.record("Expected functionDeclaration")
+        return
+    }
+    #expect(name == "doStuff")
+    #expect(body.count == 1)
+}
+
+// MARK: - Return Statement
+
+@Test("Parser parses return with value")
+func returnWithValue() throws {
+    let nodes = try parse("""
+    func doStuff() {
+        return "hello"
+    }
+    """)
+    guard case .functionDeclaration(_, let body, _) = nodes[0] else {
+        Issue.record("Expected functionDeclaration")
+        return
+    }
+    guard case .returnStatement(let value, _) = body[0] else {
+        Issue.record("Expected returnStatement")
+        return
+    }
+    #expect(value != nil)
+}
+
+// MARK: - Error Cases
+
+@Test("Parser errors on missing module name after import")
+func importMissingModule() throws {
+    #expect(throws: ParserError.self) {
+        _ = try parse("import")
+    }
+}
+
+@Test("Parser errors on missing closing paren")
+func missingClosingParen() throws {
+    #expect(throws: ParserError.self) {
+        _ = try parse("getBattery(")
+    }
+}
+
+@Test("Parser errors on unexpected token")
+func unexpectedToken() throws {
+    #expect(throws: ParserError.self) {
+        _ = try parse("42")
+    }
+}
+
+// MARK: - Multi-statement Programs
+
+@Test("Parser handles multiple statements")
+func multipleStatements() throws {
+    let nodes = try parse("""
+    import Shortcuts
+    #name: Test
+    var x = "hello"
+    getBattery() -> level
+    showResult(text: "\\(level)")
+    """)
+    #expect(nodes.count == 5)
+}
+
+} // end ParserTests

--- a/Tests/PreprocessorTests.swift
+++ b/Tests/PreprocessorTests.swift
@@ -1,0 +1,270 @@
+import Testing
+import Foundation
+@testable import perspective_cuts
+
+@Suite("Preprocessor")
+struct PreprocessorTests {
+
+    /// Creates a temporary directory with the given files and returns its URL.
+    private func makeTempDir(files: [String: String]) throws -> URL {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("perspective-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        for (name, content) in files {
+            let fileURL = tmpDir.appendingPathComponent(name)
+            // Create subdirectories if needed
+            let parent = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        return tmpDir
+    }
+
+    private func parse(_ source: String) throws -> [ASTNode] {
+        let tokens = try Lexer(source: source).tokenize()
+        return try Parser(tokens: tokens).parse()
+    }
+
+    // MARK: - Parser: #include and #fragment
+
+    @Test("Parser parses #include directive")
+    func parseInclude() throws {
+        let nodes = try parse("#include \"fragments/foo.perspective\"")
+        guard case .includeDirective(let path, _) = nodes[0] else {
+            Issue.record("Expected includeDirective")
+            return
+        }
+        #expect(path == "fragments/foo.perspective")
+    }
+
+    @Test("Parser parses #fragment marker")
+    func parseFragment() throws {
+        let nodes = try parse("#fragment")
+        guard case .fragmentMarker = nodes[0] else {
+            Issue.record("Expected fragmentMarker")
+            return
+        }
+    }
+
+    @Test("Parser errors on #include without path")
+    func includeWithoutPath() throws {
+        #expect(throws: ParserError.self) {
+            _ = try parse("#include")
+        }
+    }
+
+    // MARK: - Preprocessor: Include Resolution
+
+    @Test("Include inlines fragment actions at include site")
+    func basicInclude() throws {
+        let dir = try makeTempDir(files: [
+            "fragment.perspective": """
+            #fragment
+            // Setup step
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"fragment.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // Should have 1 node: the comment (fragment marker stripped)
+        #expect(result.count == 1)
+        guard case .comment(let text, _) = result[0] else {
+            Issue.record("Expected comment node, got \(result[0])")
+            return
+        }
+        #expect(text == "Setup step")
+    }
+
+    @Test("Include strips import and metadata from fragment")
+    func stripsImportAndMetadata() throws {
+        let dir = try makeTempDir(files: [
+            "standalone.perspective": """
+            import Shortcuts
+            #name: Helper
+            #color: blue
+            // The real work
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"standalone.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // Only the comment should survive — import and metadata stripped
+        #expect(result.count == 1)
+        guard case .comment = result[0] else {
+            Issue.record("Expected comment, got \(result[0])")
+            return
+        }
+    }
+
+    @Test("Including a non-fragment file works")
+    func includeNonFragment() throws {
+        let dir = try makeTempDir(files: [
+            "other.perspective": """
+            import Shortcuts
+            #name: Other Shortcut
+            // Action from other
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"other.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 1)
+        guard case .comment = result[0] else {
+            Issue.record("Expected comment")
+            return
+        }
+    }
+
+    @Test("Multiple includes inline in order")
+    func multipleIncludes() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": "#fragment\n// Part A",
+            "b.perspective": "#fragment\n// Part B",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        #include "a.perspective"
+        #include "b.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 2)
+        guard case .comment(let textA, _) = result[0] else {
+            Issue.record("Expected comment A")
+            return
+        }
+        guard case .comment(let textB, _) = result[1] else {
+            Issue.record("Expected comment B")
+            return
+        }
+        #expect(textA == "Part A")
+        #expect(textB == "Part B")
+    }
+
+    @Test("Include resolves relative to including file directory")
+    func relativePathResolution() throws {
+        let dir = try makeTempDir(files: [
+            "fragments/helper.perspective": "#fragment\n// Helper action"
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"fragments/helper.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 1)
+    }
+
+    @Test("Main file nodes are preserved around includes")
+    func mainNodesPreserved() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": "#fragment\n// Fragment"
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        // Before
+        #include "frag.perspective"
+        // After
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 3)
+        guard case .comment(let t0, _) = result[0] else { Issue.record("Expected comment 0"); return }
+        guard case .comment(let t1, _) = result[1] else { Issue.record("Expected comment 1"); return }
+        guard case .comment(let t2, _) = result[2] else { Issue.record("Expected comment 2"); return }
+        #expect(t0 == "Before")
+        #expect(t1 == "Fragment")
+        #expect(t2 == "After")
+    }
+
+    // MARK: - Error Cases
+
+    @Test("Include of missing file produces error")
+    func missingFile() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("perspective-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"nonexistent.perspective\"")
+
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Compiling a #fragment file directly produces error")
+    func fragmentStandaloneError() throws {
+        let nodes = try parse("""
+        #fragment
+        // Some actions
+        """)
+
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: URL(fileURLWithPath: "/tmp")).preprocess(nodes: nodes)
+        }
+    }
+
+    // MARK: - End-to-End: Include + Compile
+
+    @Test("Included fragment actions compile into final shortcut")
+    func includeAndCompile() throws {
+        let dir = try makeTempDir(files: [
+            "fragment.perspective": """
+            #fragment
+            // Setup comment
+            """
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let source = """
+        #name: Main
+        #include "fragment.perspective"
+        """
+        let tokens = try Lexer(source: source).tokenize()
+        let parsed = try Parser(tokens: tokens).parse()
+        let preprocessed = try Preprocessor(sourceDirectory: dir).preprocess(nodes: parsed)
+
+        let registry = ActionRegistry(actions: [:], controlFlow: [:], iconColors: [:])
+        let result = try Compiler(registry: registry).compile(nodes: preprocessed)
+
+        #expect(result["WFWorkflowName"] as? String == "Main")
+        let actions = result["WFWorkflowActions"] as! [[String: Any]]
+        // The comment from the fragment should be compiled as an action
+        #expect(actions.count == 1)
+        let id = actions[0]["WFWorkflowActionIdentifier"] as? String
+        #expect(id == "is.workflow.actions.comment")
+    }
+
+    @Test("Multiple fragments compose into single shortcut")
+    func multiFragmentComposition() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": "#fragment\n// Part A",
+            "b.perspective": "#fragment\n// Part B",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let source = """
+        #name: Composed
+        #include "a.perspective"
+        #include "b.perspective"
+        """
+        let tokens = try Lexer(source: source).tokenize()
+        let parsed = try Parser(tokens: tokens).parse()
+        let preprocessed = try Preprocessor(sourceDirectory: dir).preprocess(nodes: parsed)
+
+        let registry = ActionRegistry(actions: [:], controlFlow: [:], iconColors: [:])
+        let result = try Compiler(registry: registry).compile(nodes: preprocessed)
+
+        let actions = result["WFWorkflowActions"] as! [[String: Any]]
+        #expect(actions.count == 2)
+    }
+
+} // end PreprocessorTests

--- a/Tests/PreprocessorTests.swift
+++ b/Tests/PreprocessorTests.swift
@@ -703,4 +703,257 @@ struct PreprocessorTests {
         #expect(foundVarDecl, "Expected prefixed internal variable for 'input'")
     }
 
+    // MARK: - Nested Includes
+
+    @Test("Nested include resolves correctly")
+    func nestedInclude() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": """
+            #fragment
+            #include "helpers/b.perspective"
+            // From A
+            """,
+            "helpers/b.perspective": """
+            #fragment
+            // From B
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"a.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 2)
+        guard case .comment(let t0, _) = result[0] else { Issue.record("Expected comment 0"); return }
+        guard case .comment(let t1, _) = result[1] else { Issue.record("Expected comment 1"); return }
+        #expect(t0 == "From B")
+        #expect(t1 == "From A")
+    }
+
+    @Test("Three levels of nesting work")
+    func threeLevelNesting() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": "#fragment\n#include \"b.perspective\"\n// A",
+            "b.perspective": "#fragment\n#include \"c.perspective\"\n// B",
+            "c.perspective": "#fragment\n// C",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"a.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 3)
+        guard case .comment(let t0, _) = result[0] else { Issue.record("Expected C"); return }
+        guard case .comment(let t1, _) = result[1] else { Issue.record("Expected B"); return }
+        guard case .comment(let t2, _) = result[2] else { Issue.record("Expected A"); return }
+        #expect(t0 == "C")
+        #expect(t1 == "B")
+        #expect(t2 == "A")
+    }
+
+    @Test("Nested include paths resolve relative to included file")
+    func nestedRelativePaths() throws {
+        let dir = try makeTempDir(files: [
+            "fragments/api.perspective": """
+            #fragment
+            #include "helpers/http.perspective"
+            // API
+            """,
+            "fragments/helpers/http.perspective": """
+            #fragment
+            // HTTP helper
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"fragments/api.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        #expect(result.count == 2)
+        guard case .comment(let t0, _) = result[0] else { Issue.record("Expected HTTP helper"); return }
+        #expect(t0 == "HTTP helper")
+    }
+
+    @Test("Nested fragment with contracts works")
+    func nestedFragmentContracts() throws {
+        let dir = try makeTempDir(files: [
+            "outer.perspective": """
+            #fragment
+            #provides: finalResult
+            #include "inner.perspective"
+            var finalResult = innerResult
+            """,
+            "inner.perspective": """
+            #fragment
+            #provides: innerResult
+            var temp = "working"
+            var innerResult = "done"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"outer.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // inner's temp should be prefixed with inner__, not double-prefixed
+        var foundInnerTemp = false
+        var foundInnerResult = false
+        var foundFinalResult = false
+        for node in result {
+            if case .variableDeclaration(let name, _, _, _) = node {
+                if name == "inner__temp" { foundInnerTemp = true }
+                if name == "innerResult" { foundInnerResult = true }
+                if name == "finalResult" { foundFinalResult = true }
+                // Should NOT have outer__inner__temp (double-prefix)
+                #expect(!name.contains("outer__inner__"), "Double-prefixed variable found: \(name)")
+            }
+        }
+        #expect(foundInnerTemp, "Expected inner__temp")
+        #expect(foundInnerResult, "Expected innerResult (provided, not prefixed)")
+        #expect(foundFinalResult, "Expected finalResult (provided, not prefixed)")
+    }
+
+    // MARK: - Cycle Detection
+
+    @Test("Direct cycle produces error")
+    func directCycle() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": "#fragment\n#include \"b.perspective\"",
+            "b.perspective": "#fragment\n#include \"a.perspective\"",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"a.perspective\"")
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Indirect cycle produces error")
+    func indirectCycle() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": "#fragment\n#include \"b.perspective\"",
+            "b.perspective": "#fragment\n#include \"c.perspective\"",
+            "c.perspective": "#fragment\n#include \"a.perspective\"",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"a.perspective\"")
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Self-include produces error")
+    func selfInclude() throws {
+        let dir = try makeTempDir(files: [
+            "self.perspective": "#fragment\n#include \"self.perspective\"",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"self.perspective\"")
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Diamond dependency is allowed (not a cycle)")
+    func diamondDependency() throws {
+        let dir = try makeTempDir(files: [
+            "b.perspective": "#fragment\n#include \"d.perspective\"\n// B",
+            "c.perspective": "#fragment\n#include \"d.perspective\"\n// C",
+            "d.perspective": "#fragment\n// D",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        #include "b.perspective"
+        #include "c.perspective"
+        """)
+        // Should not throw — D is included twice but from separate branches
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        let comments = result.compactMap { node -> String? in
+            if case .comment(let text, _) = node { return text }
+            return nil
+        }
+        // D appears twice (once from B, once from C), plus B and C
+        #expect(comments == ["D", "B", "D", "C"])
+    }
+
+    // MARK: - Error Reporting: File Context
+
+    @Test("SourceLocation with file includes filename in description")
+    func sourceLocationFileDescription() {
+        let loc = SourceLocation(line: 5, column: 3, file: "fragments/helper.perspective")
+        #expect(loc.description.contains("fragments/helper.perspective"))
+    }
+
+    @Test("SourceLocation without file is backwards compatible")
+    func sourceLocationNoFile() {
+        let loc = SourceLocation(line: 5, column: 3)
+        #expect(loc.file == nil)
+        #expect(loc.description == "line 5, column 3")
+    }
+
+    @Test("Included fragment nodes have file set in SourceLocation")
+    func includedNodesHaveFile() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": "#fragment\n// From fragment",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        guard case .comment(_, let loc) = result[0] else {
+            Issue.record("Expected comment")
+            return
+        }
+        #expect(loc.file == "frag.perspective")
+    }
+
+    @Test("Nested include preserves inner file in SourceLocation")
+    func nestedIncludeFileContext() throws {
+        let dir = try makeTempDir(files: [
+            "outer.perspective": "#fragment\n#include \"inner.perspective\"\n// outer line",
+            "inner.perspective": "#fragment\n// inner line",
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"outer.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // "inner line" should have file = "inner.perspective" (not overwritten by outer)
+        guard case .comment(let text0, let loc0) = result[0] else {
+            Issue.record("Expected comment 0")
+            return
+        }
+        #expect(text0 == "inner line")
+        #expect(loc0.file == "inner.perspective")
+
+        // "outer line" should have file = "outer.perspective"
+        guard case .comment(let text1, let loc1) = result[1] else {
+            Issue.record("Expected comment 1")
+            return
+        }
+        #expect(text1 == "outer line")
+        #expect(loc1.file == "outer.perspective")
+    }
+
+    @Test("PreprocessorError includeChain formats correctly")
+    func preprocessorErrorIncludeChain() {
+        let error = PreprocessorError(
+            message: "unknown action",
+            location: SourceLocation(line: 5, column: 1, file: "inner.perspective"),
+            includeChain: [
+                (file: "outer.perspective", line: 3),
+                (file: "main.perspective", line: 1),
+            ]
+        )
+        let desc = error.description
+        #expect(desc.contains("inner.perspective"))
+        #expect(desc.contains("included from outer.perspective:3"))
+        #expect(desc.contains("included from main.perspective:1"))
+    }
+
 } // end PreprocessorTests

--- a/Tests/PreprocessorTests.swift
+++ b/Tests/PreprocessorTests.swift
@@ -282,7 +282,7 @@ struct PreprocessorTests {
     @Test("Parser parses #requires directive")
     func parseRequires() throws {
         let nodes = try parse("#requires: serverURL")
-        guard case .requiresDeclaration(let vars, _) = nodes[0] else {
+        guard case .requiresDeclaration(let vars, _, _) = nodes[0] else {
             Issue.record("Expected requiresDeclaration")
             return
         }
@@ -954,6 +954,214 @@ struct PreprocessorTests {
         #expect(desc.contains("inner.perspective"))
         #expect(desc.contains("included from outer.perspective:3"))
         #expect(desc.contains("included from main.perspective:1"))
+    }
+
+    // MARK: - #requires fresh
+
+    @Test("Parser parses #requires fresh directive")
+    func parseRequiresFresh() throws {
+        let nodes = try parse("#requires fresh: debugLine, debugPath")
+        guard case .requiresDeclaration(let vars, let fresh, _) = nodes[0] else {
+            Issue.record("Expected requiresDeclaration")
+            return
+        }
+        #expect(vars == ["debugLine", "debugPath"])
+        #expect(fresh == true)
+    }
+
+    @Test("Parser parses plain #requires as non-fresh")
+    func parseRequiresNotFresh() throws {
+        let nodes = try parse("#requires: serverURL")
+        guard case .requiresDeclaration(_, let fresh, _) = nodes[0] else {
+            Issue.record("Expected requiresDeclaration")
+            return
+        }
+        #expect(fresh == false)
+    }
+
+    @Test("#requires fresh passes with var set before include")
+    func freshRequiresSatisfied() throws {
+        let dir = try makeTempDir(files: [
+            "writer.perspective": """
+            #fragment
+            #requires fresh: line
+            // uses line
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        var line = "hello"
+        #include "writer.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("#requires fresh fails on second include without re-set")
+    func freshRequiresFailsSecondInclude() throws {
+        let dir = try makeTempDir(files: [
+            "writer.perspective": """
+            #fragment
+            #requires fresh: line
+            // uses line
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        var line = "hello"
+        #include "writer.perspective"
+        #include "writer.perspective"
+        """)
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("#requires fresh passes when re-set between includes")
+    func freshRequiresResetBetweenIncludes() throws {
+        let dir = try makeTempDir(files: [
+            "writer.perspective": """
+            #fragment
+            #requires fresh: line
+            // uses line
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        var line = "first"
+        #include "writer.perspective"
+        var line = "second"
+        #include "writer.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Mixed #requires and #requires fresh in same fragment")
+    func mixedRequiresAndFresh() throws {
+        let dir = try makeTempDir(files: [
+            "logger.perspective": """
+            #fragment
+            #requires: logPath
+            #requires fresh: message
+            // uses logPath and message
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // First include: both logPath and message set — should pass
+        let mainNodes = try parse("""
+        var logPath = "/tmp/log"
+        var message = "first"
+        #include "logger.perspective"
+        var message = "second"
+        #include "logger.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Mixed requires: fresh fails but non-fresh passes on second include")
+    func mixedRequiresFreshFailsSecondInclude() throws {
+        let dir = try makeTempDir(files: [
+            "logger.perspective": """
+            #fragment
+            #requires: logPath
+            #requires fresh: message
+            // uses logPath and message
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // logPath is set once (fine — not fresh), but message is not re-set
+        let mainNodes = try parse("""
+        var logPath = "/tmp/log"
+        var message = "first"
+        #include "logger.perspective"
+        #include "logger.perspective"
+        """)
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Action output capture satisfies #requires fresh")
+    func freshRequiresSatisfiedByCapture() throws {
+        let dir = try makeTempDir(files: [
+            "processor.perspective": """
+            #fragment
+            #requires fresh: data
+            // uses data
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        getBattery() -> data
+        #include "processor.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("#requires fresh with single include behaves same as #requires")
+    func freshRequiresSingleInclude() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires fresh: x
+            // uses x
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Passes: x is set before the only include
+        let mainNodes = try parse("""
+        var x = "hello"
+        #include "frag.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("#requires fresh fails when variable not in scope at all")
+    func freshRequiresNotInScope() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires fresh: missing
+            // uses missing
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Non-fresh #requires still passes on second include without re-set")
+    func nonFreshRequiresPassesSecondInclude() throws {
+        let dir = try makeTempDir(files: [
+            "reader.perspective": """
+            #fragment
+            #requires: config
+            // uses config
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        var config = "value"
+        #include "reader.perspective"
+        #include "reader.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
     }
 
 } // end PreprocessorTests

--- a/Tests/PreprocessorTests.swift
+++ b/Tests/PreprocessorTests.swift
@@ -667,4 +667,40 @@ struct PreprocessorTests {
         #expect(secondSetVar["WFVariableName"] as? String == "greeting")
     }
 
+    @Test("Auto-prefixing exempts shortcutInput built-in variable")
+    func shortcutInputNotPrefixed() throws {
+        let tmpDir = try makeTempDir(files: [
+            "main.perspective": """
+            import Shortcuts
+            #name: Test
+            #include "frag.perspective"
+            """,
+            "frag.perspective": """
+            #fragment
+            #provides: result
+            var input = shortcutInput
+            showResult(text: "\\(input)")
+            var result = input
+            """,
+        ])
+        let mainSource = try String(contentsOf: tmpDir.appendingPathComponent("main.perspective"), encoding: .utf8)
+        let nodes = try parse(mainSource)
+        let processed = try Preprocessor(sourceDirectory: tmpDir).preprocess(nodes: nodes)
+
+        // "input" should be prefixed (internal), "shortcutInput" should NOT be
+        var foundVarDecl = false
+        for node in processed {
+            if case .variableDeclaration(let name, let value, _, _) = node {
+                if name.contains("__") && name.hasSuffix("__input") {
+                    foundVarDecl = true
+                    // The value should reference unprefixed shortcutInput
+                    if case .variableReference(let ref) = value {
+                        #expect(ref == "shortcutInput", "shortcutInput should not be prefixed, got: \\(ref)")
+                    }
+                }
+            }
+        }
+        #expect(foundVarDecl, "Expected prefixed internal variable for 'input'")
+    }
+
 } // end PreprocessorTests

--- a/Tests/PreprocessorTests.swift
+++ b/Tests/PreprocessorTests.swift
@@ -267,4 +267,404 @@ struct PreprocessorTests {
         #expect(actions.count == 2)
     }
 
+    // MARK: - Parser: #provides and #requires
+
+    @Test("Parser parses #provides directive")
+    func parseProvides() throws {
+        let nodes = try parse("#provides: apiKey, serverURL")
+        guard case .providesDeclaration(let vars, _) = nodes[0] else {
+            Issue.record("Expected providesDeclaration")
+            return
+        }
+        #expect(vars == ["apiKey", "serverURL"])
+    }
+
+    @Test("Parser parses #requires directive")
+    func parseRequires() throws {
+        let nodes = try parse("#requires: serverURL")
+        guard case .requiresDeclaration(let vars, _) = nodes[0] else {
+            Issue.record("Expected requiresDeclaration")
+            return
+        }
+        #expect(vars == ["serverURL"])
+    }
+
+    @Test("Parser errors on empty #provides")
+    func emptyProvides() throws {
+        #expect(throws: ParserError.self) {
+            _ = try parse("#provides:")
+        }
+    }
+
+    // MARK: - Dependency Validation
+
+    @Test("Satisfied #requires passes validation")
+    func satisfiedRequires() throws {
+        let dir = try makeTempDir(files: [
+            "config.perspective": """
+            #fragment
+            #provides: apiKey
+            var apiKey = "sk-123"
+            """,
+            "api.perspective": """
+            #fragment
+            #requires: apiKey
+            #provides: result
+            // uses apiKey
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        #include "config.perspective"
+        #include "api.perspective"
+        """)
+        // Should not throw
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Main file var satisfies #requires")
+    func mainFileVarSatisfiesRequires() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires: serverURL
+            // uses serverURL
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        var serverURL = "https://example.com"
+        #include "frag.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Main file -> capture satisfies #requires")
+    func mainFileOutputSatisfiesRequires() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires: data
+            // uses data
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        getBattery() -> data
+        #include "frag.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Unsatisfied #requires produces error")
+    func unsatisfiedRequires() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires: missingVar
+            // needs missingVar
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    @Test("Duplicate #provides produces error")
+    func duplicateProvides() throws {
+        let dir = try makeTempDir(files: [
+            "a.perspective": """
+            #fragment
+            #provides: token
+            var token = "abc"
+            """,
+            "b.perspective": """
+            #fragment
+            #provides: token
+            var token = "xyz"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        #include "a.perspective"
+        #include "b.perspective"
+        """)
+        #expect(throws: PreprocessorError.self) {
+            _ = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+        }
+    }
+
+    // MARK: - Variable Auto-Prefixing
+
+    @Test("Fragment prefix derives camelCase from filename")
+    func fragmentPrefixDerivation() {
+        #expect(Preprocessor.fragmentPrefix(from: "config-loader.perspective") == "configLoader__")
+        #expect(Preprocessor.fragmentPrefix(from: "fragments/api-call.perspective") == "apiCall__")
+        #expect(Preprocessor.fragmentPrefix(from: "simple.perspective") == "simple__")
+        #expect(Preprocessor.fragmentPrefix(from: "a_b_c.perspective") == "aBC__")
+    }
+
+    @Test("Internal variables are prefixed")
+    func internalVarsPrefixed() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #provides: result
+            var temp = "working"
+            var result = "done"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // temp should be prefixed, result should not
+        guard case .variableDeclaration(let name1, _, _, _) = result[0] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        guard case .variableDeclaration(let name2, _, _, _) = result[1] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        #expect(name1 == "frag__temp")
+        #expect(name2 == "result")
+    }
+
+    @Test("Action output captures are prefixed when internal")
+    func outputCapturesPrefixed() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #provides: finalResult
+            // internal capture gets prefixed
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let dir2 = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #provides: publicVar
+            getBattery() -> internalOutput
+            var publicVar = "done"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir2) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir2).preprocess(nodes: mainNodes)
+
+        // getBattery() -> frag__internalOutput
+        guard case .actionCall(_, _, let output, _) = result[0] else {
+            Issue.record("Expected action call")
+            return
+        }
+        #expect(output == "frag__internalOutput")
+
+        // var publicVar = "done" (not prefixed)
+        guard case .variableDeclaration(let name, _, _, _) = result[1] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        #expect(name == "publicVar")
+    }
+
+    @Test("Variable references in expressions are prefixed")
+    func expressionReferencesPrefixed() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #provides: output
+            var temp = "hello"
+            var output = temp
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // var frag__temp = "hello"
+        guard case .variableDeclaration(let name1, _, _, _) = result[0] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        #expect(name1 == "frag__temp")
+
+        // var output = frag__temp  (reference should be prefixed)
+        guard case .variableDeclaration(let name2, let value, _, _) = result[1] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        #expect(name2 == "output")
+        guard case .variableReference(let ref) = value else {
+            Issue.record("Expected variable reference")
+            return
+        }
+        #expect(ref == "frag__temp")
+    }
+
+    @Test("Interpolated string variable references are prefixed")
+    func interpolationReferencesPrefixed() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #provides: msg
+            var temp = "world"
+            var msg = "hello \\(temp)"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"frag.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        guard case .variableDeclaration(_, let value, _, _) = result[1] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        guard case .interpolatedString(let parts) = value else {
+            Issue.record("Expected interpolated string")
+            return
+        }
+        // Should have text "hello " and variable "frag__temp"
+        guard case .variable(let varName) = parts[1] else {
+            Issue.record("Expected variable part")
+            return
+        }
+        #expect(varName == "frag__temp")
+    }
+
+    @Test("For-each loop variables are NOT prefixed")
+    func loopVarsExempt() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires: items
+            #provides: count
+            var count = 0
+            for item in items {
+                var count = 0
+            }
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        getBattery() -> items
+        #include "frag.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // Find the for-each loop node
+        let forNode = result.first(where: { if case .forEachLoop = $0 { return true } else { return false } })
+        guard case .forEachLoop(let itemName, _, _, _) = forNode else {
+            Issue.record("Expected forEachLoop")
+            return
+        }
+        #expect(itemName == "item") // NOT frag__item
+    }
+
+    @Test("Requires variables are NOT prefixed in references")
+    func requiresVarsNotPrefixed() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #requires: apiKey
+            #provides: result
+            var result = apiKey
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("""
+        var apiKey = "sk-123"
+        #include "frag.perspective"
+        """)
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        // The fragment's "var result = apiKey" — apiKey should NOT be prefixed
+        let fragVarNode = result.last!
+        guard case .variableDeclaration(let name, let value, _, _) = fragVarNode else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        #expect(name == "result")
+        guard case .variableReference(let ref) = value else {
+            Issue.record("Expected variable reference")
+            return
+        }
+        #expect(ref == "apiKey") // NOT frag__apiKey
+    }
+
+    @Test("Fragments without contracts are NOT prefixed")
+    func noContractsNoPrefixing() throws {
+        let dir = try makeTempDir(files: [
+            "simple.perspective": """
+            #fragment
+            var temp = "hello"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let mainNodes = try parse("#include \"simple.perspective\"")
+        let result = try Preprocessor(sourceDirectory: dir).preprocess(nodes: mainNodes)
+
+        guard case .variableDeclaration(let name, _, _, _) = result[0] else {
+            Issue.record("Expected var declaration")
+            return
+        }
+        #expect(name == "temp") // NOT prefixed since no #provides/#requires
+    }
+
+    // MARK: - End-to-End: Phase 2 with Compilation
+
+    @Test("Auto-prefixed fragment compiles correctly")
+    func prefixedFragmentCompiles() throws {
+        let dir = try makeTempDir(files: [
+            "frag.perspective": """
+            #fragment
+            #provides: greeting
+            var temp = "world"
+            var greeting = "hello"
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let source = """
+        #name: Test
+        #include "frag.perspective"
+        """
+        let tokens = try Lexer(source: source).tokenize()
+        let parsed = try Parser(tokens: tokens).parse()
+        let preprocessed = try Preprocessor(sourceDirectory: dir).preprocess(nodes: parsed)
+
+        let registry = ActionRegistry(actions: [:], controlFlow: [:], iconColors: [:])
+        let result = try Compiler(registry: registry).compile(nodes: preprocessed)
+
+        let actions = result["WFWorkflowActions"] as! [[String: Any]]
+        // temp: text + setvariable, greeting: text + setvariable = 4 actions
+        #expect(actions.count == 4)
+
+        // First setvariable should use prefixed name "frag__temp"
+        let firstSetVar = actions[1]["WFWorkflowActionParameters"] as! [String: Any]
+        #expect(firstSetVar["WFVariableName"] as? String == "frag__temp")
+
+        // Second setvariable should use unprefixed "greeting"
+        let secondSetVar = actions[3]["WFWorkflowActionParameters"] as! [String: Any]
+        #expect(secondSetVar["WFVariableName"] as? String == "greeting")
+    }
+
 } // end PreprocessorTests

--- a/Tests/SiriTimeoutAnalyzerTests.swift
+++ b/Tests/SiriTimeoutAnalyzerTests.swift
@@ -1,0 +1,195 @@
+import Testing
+@testable import perspective_cuts
+
+@Suite("SiriTimeoutAnalyzer")
+struct SiriTimeoutAnalyzerTests {
+
+    private let registry = ActionRegistry(
+        actions: [
+            "downloadURL": ActionDefinition(
+                identifier: "is.workflow.actions.downloadurl",
+                description: "Download URL",
+                parameters: [
+                    "url": ActionParameter(type: "string", required: true, key: "WFURL")
+                ]
+            ),
+            "showResult": ActionDefinition(
+                identifier: "is.workflow.actions.showresult",
+                description: "Show result",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "Text")
+                ]
+            ),
+            "text": ActionDefinition(
+                identifier: "is.workflow.actions.gettext",
+                description: "Get text",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "WFTextActionText")
+                ]
+            ),
+            "runShortcut": ActionDefinition(
+                identifier: "is.workflow.actions.runworkflow",
+                description: "Run shortcut",
+                parameters: [
+                    "name": ActionParameter(type: "variable", required: true, key: "WFWorkflowName")
+                ]
+            ),
+            "getCurrentLocation": ActionDefinition(
+                identifier: "is.workflow.actions.getcurrentlocation",
+                description: "Get current location",
+                parameters: [:]
+            ),
+            "speakText": ActionDefinition(
+                identifier: "is.workflow.actions.speaktext",
+                description: "Speak text",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "WFText")
+                ]
+            ),
+        ],
+        controlFlow: [:],
+        iconColors: [:]
+    )
+
+    private func loc(_ line: Int) -> perspective_cuts.SourceLocation {
+        perspective_cuts.SourceLocation(line: line, column: 1)
+    }
+
+    @Test("No warnings for shortcut with no slow actions")
+    func noSlowActions() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "text", arguments: [(label: "text", value: .stringLiteral("hi"))], output: nil, location: loc(1)),
+            .actionCall(name: "showResult", arguments: [(label: "text", value: .variableReference("r"))], output: nil, location: loc(2)),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        #expect(analyzer.analyze(nodes: nodes).isEmpty)
+    }
+
+    @Test("No warnings when output precedes slow action")
+    func outputBeforeSlow() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "showResult", arguments: [(label: "text", value: .stringLiteral("Loading..."))], output: nil, location: loc(1)),
+            .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(2)),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        #expect(analyzer.analyze(nodes: nodes).isEmpty)
+    }
+
+    @Test("Warns when slow action has no prior output")
+    func slowWithoutOutput() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(1)),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].actionName == "downloadURL")
+        #expect(diags[0].branchContext == nil)
+    }
+
+    @Test("Output in parent scope protects actions in branches")
+    func outputProtectsBranch() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "showResult", arguments: [(label: "text", value: .stringLiteral("Starting..."))], output: nil, location: loc(1)),
+            .ifStatement(
+                condition: .equals(left: .variableReference("x"), right: .stringLiteral("y")),
+                thenBody: [
+                    .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(4)),
+                ],
+                elseBody: nil,
+                location: loc(2)
+            ),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        #expect(analyzer.analyze(nodes: nodes).isEmpty)
+    }
+
+    @Test("Slow action in branch without prior output warns with context")
+    func slowInBranch() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("mode"), right: .stringLiteral("fetch")),
+                thenBody: [
+                    .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(4)),
+                ],
+                elseBody: nil,
+                location: loc(2)
+            ),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "when mode == \"fetch\"")
+    }
+
+    @Test("Output inside branch does not protect sibling branch")
+    func outputInOneBranchOnly() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("x"), right: .stringLiteral("a")),
+                thenBody: [
+                    .actionCall(name: "showResult", arguments: [(label: "text", value: .stringLiteral("hi"))], output: nil, location: loc(3)),
+                    .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(4)),
+                ],
+                elseBody: [
+                    // No output here, so downloadURL should warn
+                    .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://other.com"))], output: nil, location: loc(6)),
+                ],
+                location: loc(2)
+            ),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].location.line == 6) // only the else branch
+    }
+
+    @Test("Multiple slow actions without output reports all of them")
+    func multipleSlowActions() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://a.com"))], output: nil, location: loc(1)),
+            .actionCall(name: "getCurrentLocation", arguments: [], output: nil, location: loc(2)),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 2)
+    }
+
+    @Test("speakText counts as output")
+    func speakTextIsOutput() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "speakText", arguments: [(label: "text", value: .stringLiteral("Loading"))], output: nil, location: loc(1)),
+            .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(2)),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        #expect(analyzer.analyze(nodes: nodes).isEmpty)
+    }
+
+    @Test("runShortcut is flagged as potentially slow")
+    func runShortcutIsSlow() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "runShortcut", arguments: [(label: "name", value: .stringLiteral("Helper"))], output: nil, location: loc(1)),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].actionName == "runShortcut")
+    }
+
+    @Test("For-each inherits parent output state")
+    func forEachInheritsOutput() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "showResult", arguments: [(label: "text", value: .stringLiteral("Starting"))], output: nil, location: loc(1)),
+            .forEachLoop(
+                itemName: "item",
+                collection: .variableReference("items"),
+                body: [
+                    .actionCall(name: "downloadURL", arguments: [(label: "url", value: .stringLiteral("https://example.com"))], output: nil, location: loc(4)),
+                ],
+                location: loc(2)
+            ),
+        ]
+        let analyzer = SiriTimeoutAnalyzer(registry: registry)
+        #expect(analyzer.analyze(nodes: nodes).isEmpty)
+    }
+}

--- a/Tests/StandaloneAnalyzerTests.swift
+++ b/Tests/StandaloneAnalyzerTests.swift
@@ -1,0 +1,167 @@
+import Testing
+@testable import perspective_cuts
+
+@Suite("StandaloneAnalyzer")
+struct StandaloneAnalyzerTests {
+
+    private let registry = ActionRegistry(
+        actions: [
+            "runShortcut": ActionDefinition(
+                identifier: "is.workflow.actions.runworkflow",
+                description: "Run another shortcut",
+                parameters: [
+                    "name": ActionParameter(type: "variable", required: true, key: "WFWorkflowName"),
+                    "input": ActionParameter(type: "variable", required: false, key: "WFInput"),
+                ]
+            ),
+            "text": ActionDefinition(
+                identifier: "is.workflow.actions.gettext",
+                description: "Get text",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "WFTextActionText")
+                ]
+            ),
+            "showResult": ActionDefinition(
+                identifier: "is.workflow.actions.showresult",
+                description: "Show result",
+                parameters: [
+                    "text": ActionParameter(type: "string", required: true, key: "Text")
+                ]
+            ),
+        ],
+        controlFlow: [:],
+        iconColors: [:]
+    )
+
+    private func loc(_ line: Int) -> perspective_cuts.SourceLocation {
+        perspective_cuts.SourceLocation(line: line, column: 1)
+    }
+
+    @Test("No diagnostics for self-contained shortcut")
+    func selfContained() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "text", arguments: [(label: "text", value: .stringLiteral("hello"))], output: nil, location: loc(1)),
+            .actionCall(name: "showResult", arguments: [(label: "text", value: .variableReference("result"))], output: nil, location: loc(2)),
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.isEmpty)
+    }
+
+    @Test("Detects runShortcut as dependency")
+    func runShortcutDependency() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "runShortcut", arguments: [(label: "name", value: .stringLiteral("Log Helper"))], output: nil, location: loc(3))
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].description.contains("shortcut \"Log Helper\""))
+        #expect(diags[0].branchContext == nil)
+    }
+
+    @Test("Detects 3rd-party app action as dependency")
+    func thirdPartyDependency() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "com.openai.chat.AskIntent", arguments: [(label: "prompt", value: .stringLiteral("hi"))], output: nil, location: loc(5))
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].description.contains("3rd-party action com.openai.chat.AskIntent"))
+    }
+
+    @Test("Reports branch context for conditional dependency")
+    func conditionalDependency() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("mode"), right: .stringLiteral("advanced")),
+                thenBody: [
+                    .actionCall(name: "runShortcut", arguments: [(label: "name", value: .stringLiteral("Helper"))], output: nil, location: loc(4))
+                ],
+                elseBody: nil,
+                location: loc(2)
+            )
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "when mode == \"advanced\"")
+    }
+
+    @Test("Reports menu case context")
+    func menuDependency() {
+        let nodes: [ASTNode] = [
+            .menu(
+                title: "Choose",
+                cases: [
+                    (label: "Local", body: [
+                        .actionCall(name: "text", arguments: [(label: "text", value: .stringLiteral("ok"))], output: nil, location: loc(4))
+                    ]),
+                    (label: "Remote", body: [
+                        .actionCall(name: "com.example.app.DoThing", arguments: [], output: nil, location: loc(6))
+                    ]),
+                ],
+                location: loc(2)
+            )
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "in menu \"Choose\" case \"Remote\"")
+    }
+
+    @Test("Detects both shortcut and 3rd-party dependencies")
+    func multipleDependencyTypes() {
+        let nodes: [ASTNode] = [
+            .actionCall(name: "runShortcut", arguments: [(label: "name", value: .stringLiteral("Helper"))], output: nil, location: loc(1)),
+            .actionCall(name: "com.openai.chat.AskIntent", arguments: [], output: nil, location: loc(2)),
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 2)
+    }
+
+    @Test("Nested if reports composed context")
+    func nestedIfContext() {
+        let nodes: [ASTNode] = [
+            .ifStatement(
+                condition: .equals(left: .variableReference("a"), right: .stringLiteral("1")),
+                thenBody: [
+                    .ifStatement(
+                        condition: .equals(left: .variableReference("b"), right: .stringLiteral("2")),
+                        thenBody: [
+                            .actionCall(name: "runShortcut", arguments: [(label: "name", value: .stringLiteral("Deep"))], output: nil, location: loc(7))
+                        ],
+                        elseBody: nil,
+                        location: loc(5)
+                    )
+                ],
+                elseBody: nil,
+                location: loc(3)
+            )
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == "when a == \"1\", when b == \"2\"")
+    }
+
+    @Test("For-each inherits parent context")
+    func forEachContext() {
+        let nodes: [ASTNode] = [
+            .forEachLoop(
+                itemName: "item",
+                collection: .variableReference("items"),
+                body: [
+                    .actionCall(name: "com.example.app.Process", arguments: [], output: nil, location: loc(4))
+                ],
+                location: loc(2)
+            )
+        ]
+        let analyzer = StandaloneAnalyzer(registry: registry)
+        let diags = analyzer.analyze(nodes: nodes)
+        #expect(diags.count == 1)
+        #expect(diags[0].branchContext == nil)
+    }
+}

--- a/bin/run-shortcut-test
+++ b/bin/run-shortcut-test
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Build, install (if needed), and run a .perspective shortcut headlessly.
+# Captures stdout for assertion.
+#
+# Usage:
+#   bin/run-shortcut-test <path/to/foo.perspective> [-i <input-file>]
+#
+# Requires:
+#   - perspective-cuts on PATH (or run from this repo via `swift run perspective-cuts`)
+#   - Accessibility + Automation permissions for Terminal (one-time grant)
+#
+# See docs/dev-workflow.md.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <path/to/foo.perspective> [-i <input-file>]" >&2
+    exit 2
+fi
+
+SOURCE="$1"
+shift
+INPUT_ARGS=()
+if [[ ${1:-} == "-i" ]]; then
+    INPUT_ARGS=(-i "$2")
+    shift 2
+fi
+
+if [[ ! -f "$SOURCE" ]]; then
+    echo "error: source not found: $SOURCE" >&2
+    exit 1
+fi
+
+# Resolve compiler: prefer PATH, fall back to local debug build.
+if command -v perspective-cuts >/dev/null 2>&1; then
+    PC=(perspective-cuts)
+elif [[ -x ".build/debug/perspective-cuts" ]]; then
+    PC=(.build/debug/perspective-cuts)
+else
+    echo "error: perspective-cuts not on PATH and .build/debug/perspective-cuts not found" >&2
+    echo "  run 'swift build' first, or install perspective-cuts" >&2
+    exit 1
+fi
+
+# Extract #name from source, fall back to capitalized basename.
+SHORTCUT_NAME="$(grep -m1 '^#name:' "$SOURCE" | sed 's/^#name:[[:space:]]*//' || true)"
+if [[ -z "$SHORTCUT_NAME" ]]; then
+    base="$(basename "$SOURCE" .perspective)"
+    SHORTCUT_NAME="${base^}"
+fi
+
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/run-shortcut-test-XXXXXX")"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+COMPILED="${BUILD_DIR}/${SHORTCUT_NAME}.shortcut"
+
+echo "==> compiling $SOURCE -> $COMPILED" >&2
+"${PC[@]}" compile --sign -o "$COMPILED" "$SOURCE"
+
+# Idempotent install: skip if already in library.
+if shortcuts list | grep -Fxq "$SHORTCUT_NAME"; then
+    echo "==> already installed: $SHORTCUT_NAME (skipping import)" >&2
+else
+    echo "==> installing $SHORTCUT_NAME via Shortcuts app + System Events" >&2
+    open "$COMPILED"
+
+    # Wait for Shortcuts import window, then press Return to default-action
+    # the "Add Shortcut" button. This is the only step that needs a one-time
+    # Accessibility/Automation grant for Terminal.
+    osascript <<'OSA' >&2
+tell application "System Events"
+    tell process "Shortcuts"
+        repeat 40 times
+            if exists window 1 then exit repeat
+            delay 0.1
+        end repeat
+        set frontmost to true
+        delay 0.3
+        keystroke return
+    end tell
+end tell
+OSA
+
+    # Verify install landed.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if shortcuts list | grep -Fxq "$SHORTCUT_NAME"; then
+            break
+        fi
+        sleep 0.5
+    done
+    if ! shortcuts list | grep -Fxq "$SHORTCUT_NAME"; then
+        echo "error: install did not land — '$SHORTCUT_NAME' not in shortcuts list" >&2
+        echo "  if a dialog is still on screen, the import-dialog UI may have changed" >&2
+        echo "  see docs/dev-workflow.md" >&2
+        exit 1
+    fi
+    osascript -e 'tell application "Shortcuts" to quit' 2>/dev/null || true
+fi
+
+OUTPUT="${BUILD_DIR}/output.txt"
+echo "==> running: shortcuts run \"$SHORTCUT_NAME\" -o $OUTPUT ${INPUT_ARGS[*]:-}" >&2
+shortcuts run "$SHORTCUT_NAME" -o "$OUTPUT" "${INPUT_ARGS[@]}"
+
+if [[ -f "$OUTPUT" ]]; then
+    cat "$OUTPUT"
+fi

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,0 +1,86 @@
+# Developer Workflow: Build → Install → Run → Inspect
+
+When fixing compiler bugs (e.g. [#9](https://github.com/akostibas/perspective-cuts/issues/9)), the fast feedback loop is:
+
+1. Edit the compiler / registry
+2. `swift build`
+3. Compile a fixture `.perspective` to a signed `.shortcut`
+4. Install it into the Shortcuts library
+5. Run it headlessly
+6. Inspect captured stdout
+
+`bin/run-shortcut-test` collapses steps 3–6 into one command.
+
+## Usage
+
+```sh
+swift build
+bin/run-shortcut-test path/to/fixture.perspective [-i input-file]
+```
+
+The script:
+- Reads `#name:` from the source (falls back to capitalized basename).
+- Compiles with `--sign`.
+- Skips install if the shortcut is already in `shortcuts list` (idempotent — see gotcha below).
+- Otherwise `open`s the `.shortcut` and uses `osascript` to press Return on the import dialog.
+- Runs `shortcuts run <name> -o <tmpfile>` and prints the captured output.
+
+## One-time setup
+
+- **Accessibility permission for Terminal** — System Settings → Privacy & Security → Accessibility. macOS prompts on first run; without it `osascript` cannot drive System Events.
+- **Automation permission for Terminal → System Events** — separate prompt, also one-time.
+
+Per-fixture, the first run may show:
+- "Allow `<name>` to output N text items?" — click "Always Allow" once.
+- Permission prompts for resources the fixture touches (network, files, contacts, etc.).
+
+## Why GUI scripting
+
+The spike that produced this loop evaluated several alternatives:
+
+| Approach | Result |
+|----------|--------|
+| `shortcuts import` subcommand | Doesn't exist. CLI has only `run`, `list`, `view`, `sign`. |
+| AppleScript `add` / `import` verb | Not in the sdef. |
+| Drop file into `~/Library/Group Containers/group.com.apple.shortcuts/` | CoreData + CloudKit; fragile, breaks across OS updates, risks sync corruption. |
+| `shortcuts://import-shortcut?url=...` | Routes through the same import dialog. |
+| `keystroke return` to default-action the dialog | **Works.** Default button is "Add Shortcut"; Return triggers it. |
+
+## Idempotent install gotcha
+
+The harness skips install if `shortcuts list` already shows the fixture's `#name:`. After editing fixture *logic*, either:
+
+- Bump the name (`Foo` → `FooV2`) to force a fresh install, or
+- Manually delete the existing shortcut from the Shortcuts app sidebar before re-running.
+
+Otherwise your edits don't reach the running shortcut.
+
+## Modals block `shortcuts run`
+
+`shortcuts run` waits for completion. Any `showResult`, `alert`, `ask`, `chooseFromList` will block until dismissed. For test fixtures, prefer **UI-free** sources:
+
+- The last action's value is what `-o` captures — no `showResult` needed.
+- Input via `-i input-file`; the shortcut sees it as `shortcutInput`.
+
+When the UI itself is the system under test, pre-arm a background `osascript` driver that polls for the modal window and dispatches keystrokes — same pattern as the install-dialog driver in `bin/run-shortcut-test`, generalized.
+
+## Inspecting compiled output
+
+Independent of the run loop, you can diff the generated plist against an Apple-built reference:
+
+```sh
+.build/debug/perspective-cuts compile fixture.perspective -o /tmp/x.shortcut
+plutil -convert xml1 -o - /tmp/x.shortcut | less
+```
+
+Useful when debugging shape mismatches like #9 (`WFTextTokenAttachment` vs. `WFTextTokenString`). Build the same action in Shortcuts.app, export, and compare.
+
+## Known limitations
+
+- **No clean uninstall via CLI.** AppleScript `delete shortcut` returns no error but doesn't actually remove. Reuse stable names rather than create-and-destroy per run.
+- **Brittle to UI changes.** If Apple adds a confirmation step to the import dialog, `keystroke return` may need to grow another step. The harness checks `shortcuts list` post-install and fails loudly.
+- **macOS-only.** No CLI on iOS.
+
+---
+
+Adapted from Shannon-Assistant's `docs/client-shortcuts/automated-testing.md`.


### PR DESCRIPTION
## Summary

- `splitText(separator: ",")` (and `combineText(separator: ",")`) silently produced wrong output: Shortcuts ignored `WFTextSeparator = ","`, fell back to the default (New Lines), and returned a single-element list.
- Apple's schema expects `WFTextSeparator` to be an enum (\"New Lines\", \"Spaces\", \"Every Character\", \"Custom\"), with a sibling `WFTextCustomSeparator` carrying the actual character when the enum is \"Custom\".
- New `textSeparator` param type accepts any string and auto-routes: known enum values pass through; anything else auto-promotes to `Custom` and injects `WFTextCustomSeparator`.

## Test plan

- [x] `swift test` — 179/179 passing
- [x] End-to-end on macOS 26.4: a 3-element comma-separated string now splits into 3 list items and iterates the for-each loop three times (was 1 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)