### PR TITLE
Fix splitText/combineText custom separator

### DIFF
--- a/Sources/perspective-cuts/Compiler/Compiler.swift
+++ b/Sources/perspective-cuts/Compiler/Compiler.swift
@@ -186,6 +186,25 @@ struct Compiler: Sendable {
                                 resolvedValue = intVal
                             } else if let paramType = paramDef?.type, (paramType == "enum" || paramType == "boolean" || paramType == "plainString") {
                                 resolvedValue = try expressionToPlainValue(value, outputMap: outputMap)
+                            } else if let paramType = paramDef?.type, paramType == "textSeparator",
+                                      case .stringLiteral(let s) = value {
+                                // Shortcuts' splitText/combineText take WFTextSeparator
+                                // as an enum ("New Lines", "Spaces", "Every Character",
+                                // "Custom"). When the enum is "Custom", a sibling
+                                // WFTextCustomSeparator carries the actual character.
+                                // Accept any string from the user and auto-route:
+                                // known enum values pass through; anything else becomes
+                                // a Custom separator. Without this, `separator: ","`
+                                // silently set WFTextSeparator="," and Shortcuts fell
+                                // back to the default (New Lines), producing a single-
+                                // element list instead of three.
+                                let knownEnums: Set<String> = ["New Lines", "Spaces", "Every Character", "Custom"]
+                                if knownEnums.contains(s) {
+                                    resolvedValue = s
+                                } else {
+                                    resolvedValue = "Custom"
+                                    params["WFTextCustomSeparator"] = s
+                                }
                             } else if Compiler.appleBuiltinPlainKeys.contains(plistKey) {
                                 // Apple plist keys that must be plain strings
                                 // (variable names, shell choice, script body,

--- a/Sources/perspective-cuts/Resources/actions.json
+++ b/Sources/perspective-cuts/Resources/actions.json
@@ -541,14 +541,9 @@
           "key": "text"
         },
         "separator": {
-          "type": "string",
+          "type": "textSeparator",
           "required": false,
           "key": "WFTextSeparator"
-        },
-        "customSeparator": {
-          "type": "string",
-          "required": false,
-          "key": "WFTextCustomSeparator"
         }
       }
     },
@@ -562,14 +557,9 @@
           "key": "text"
         },
         "separator": {
-          "type": "string",
+          "type": "textSeparator",
           "required": false,
           "key": "WFTextSeparator"
-        },
-        "customSeparator": {
-          "type": "string",
-          "required": false,
-          "key": "WFTextCustomSeparator"
         }
       }
     },


### PR DESCRIPTION
## Summary

`separator: ","` silently set `WFTextSeparator=","` which Shortcuts ignored, falling back to the default (`New Lines`) and producing a single-element list. Apple's schema expects `WFTextSeparator` to be an enum (`New Lines`, `Spaces`, `Every Character`, `Custom`) with a sibling `WFTextCustomSeparator` carrying the actual character when the enum is `Custom`.

New `textSeparator` param type accepts any string from the user: known enum values pass through; anything else auto-promotes to `Custom` and injects `WFTextCustomSeparator` alongside.

## Test plan

- [x] `swift build` succeeds
- [ ] Compile a shortcut using `splitText(text: "a,b,c", separator: ",")` and confirm Shortcuts produces a 3-element list (instead of a single-element list)
- [ ] Compile with `separator: "New Lines"` and confirm the enum value passes through unchanged
- [ ] Compile with `separator: "Spaces"` / `"Every Character"` / `"Custom"` and confirm enum pass-through
- [ ] Same tests against `combineText`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>